### PR TITLE
New feature to load API-Definition from FE-API

### DIFF
--- a/modules/api-export/src/main/java/com/axway/apim/APIExportApp.java
+++ b/modules/api-export/src/main/java/com/axway/apim/APIExportApp.java
@@ -17,6 +17,7 @@ import com.axway.apim.cli.APIMCLIServiceProvider;
 import com.axway.apim.cli.CLIServiceMethod;
 import com.axway.apim.lib.errorHandling.AppException;
 import com.axway.apim.lib.errorHandling.ErrorCode;
+import com.axway.apim.lib.errorHandling.ErrorCodeMapper;
 import com.axway.apim.lib.errorHandling.ErrorState;
 import com.axway.apim.lib.utils.rest.APIMHttpClient;
 
@@ -27,6 +28,8 @@ import com.axway.apim.lib.utils.rest.APIMHttpClient;
 public class APIExportApp implements APIMCLIServiceProvider {
 
 	private static Logger LOG = LoggerFactory.getLogger(APIExportApp.class);
+	
+	private static ErrorState errorState = ErrorState.getInstance();
 
 	public static void main(String args[]) { 
 		int rc = export(args);
@@ -44,6 +47,16 @@ public class APIExportApp implements APIMCLIServiceProvider {
 				return runExport(params, APIListImpl.JSON_EXPORTER);
 			default:
 				return runExport(params, APIListImpl.CONSOLE_EXPORTER);
+			}
+		} catch (AppException e) {
+			
+			if(errorState.hasError()) {
+				errorState.logErrorMessages(LOG);
+				if(errorState.isLogStackTrace()) LOG.error(e.getMessage(), e);
+				return new ErrorCodeMapper().getMapedErrorCode(errorState.getErrorCode()).getCode();
+			} else {
+				LOG.error(e.getMessage(), e);
+				return new ErrorCodeMapper().getMapedErrorCode(e.getErrorCode()).getCode();
 			}
 		} catch (Exception e) {
 			LOG.error(e.getMessage(), e);

--- a/modules/api-export/src/main/java/com/axway/apim/api/export/impl/APIResultHandler.java
+++ b/modules/api-export/src/main/java/com/axway/apim/api/export/impl/APIResultHandler.java
@@ -80,7 +80,8 @@ public abstract class APIResultHandler {
 				.hasBackendBasepath(params.getValue("backend"))
 				.includeCustomProperties(APIManagerAdapter.getAllConfiguredCustomProperties(CUSTOM_PROP_TYPE.api))
 				.translateMethods(METHOD_TRANSLATION.AS_NAME)
-				.translatePolicies(POLICY_TRANSLATION.TO_NAME);
+				.translatePolicies(POLICY_TRANSLATION.TO_NAME)
+				.useAPIProxyAPIDefinition(params.isUseAPIProxyAPIDefinition());
 		return builder;
 	}
 	

--- a/modules/api-export/src/main/java/com/axway/apim/api/export/impl/APIResultHandler.java
+++ b/modules/api-export/src/main/java/com/axway/apim/api/export/impl/APIResultHandler.java
@@ -81,7 +81,7 @@ public abstract class APIResultHandler {
 				.includeCustomProperties(APIManagerAdapter.getAllConfiguredCustomProperties(CUSTOM_PROP_TYPE.api))
 				.translateMethods(METHOD_TRANSLATION.AS_NAME)
 				.translatePolicies(POLICY_TRANSLATION.TO_NAME)
-				.useAPIProxyAPIDefinition(params.isUseAPIProxyAPIDefinition());
+				.useFEAPIDefinition(params.isUseFEAPIDefinition());
 		return builder;
 	}
 	

--- a/modules/api-export/src/main/java/com/axway/apim/api/export/lib/APIExportCLIOptions.java
+++ b/modules/api-export/src/main/java/com/axway/apim/api/export/lib/APIExportCLIOptions.java
@@ -23,7 +23,7 @@ public abstract class APIExportCLIOptions extends StandardExportCLIOptions {
 		option.setArgName("/api/v1/my/great/api");
 		options.addOption(option);
 		
-		option = new Option("useAPIProxyAPIDefinition", "If this flag is set, the export API contains the API-Definition (e.g. Swagger) from the FE-API instead of the original imported API.");
+		option = new Option("useFEAPIDefinition", "If this flag is set, the export API contains the API-Definition (e.g. Swagger) from the FE-API instead of the original imported API.");
 		option.setRequired(false);
 		options.addOption(option);
 		

--- a/modules/api-export/src/main/java/com/axway/apim/api/export/lib/APIExportCLIOptions.java
+++ b/modules/api-export/src/main/java/com/axway/apim/api/export/lib/APIExportCLIOptions.java
@@ -23,6 +23,10 @@ public abstract class APIExportCLIOptions extends StandardExportCLIOptions {
 		option.setArgName("/api/v1/my/great/api");
 		options.addOption(option);
 		
+		option = new Option("useAPIProxyAPIDefinition", "If this flag is set, the export API contains the API-Definition (e.g. Swagger) from the FE-API instead of the original imported API.");
+		option.setRequired(false);
+		options.addOption(option);
+		
 		option = new Option("n", "name", true, "The name of the API. Wildcards at the beginning/end are supported. Use '*' to export all APIs.");
 		option.setRequired(false);
 		option.setArgName("*MyName*");

--- a/modules/api-export/src/main/java/com/axway/apim/api/export/lib/APIExportParams.java
+++ b/modules/api-export/src/main/java/com/axway/apim/api/export/lib/APIExportParams.java
@@ -29,8 +29,8 @@ public class APIExportParams extends StandardExportParams {
 		return (getValue("localFolder")==null) ? "." : getValue("localFolder");
 	}
 	
-	public boolean isUseAPIProxyAPIDefinition() {
-		if(hasOption("useAPIProxyAPIDefinition")) return true;
+	public boolean isUseFEAPIDefinition() {
+		if(hasOption("useFEAPIDefinition")) return true;
 		return false;
 	}
 }

--- a/modules/api-export/src/main/java/com/axway/apim/api/export/lib/APIExportParams.java
+++ b/modules/api-export/src/main/java/com/axway/apim/api/export/lib/APIExportParams.java
@@ -28,4 +28,9 @@ public class APIExportParams extends StandardExportParams {
 	public String getLocalFolder() {
 		return (getValue("localFolder")==null) ? "." : getValue("localFolder");
 	}
+	
+	public boolean isUseAPIProxyAPIDefinition() {
+		if(hasOption("useAPIProxyAPIDefinition")) return true;
+		return false;
+	}
 }

--- a/modules/api-import/src/main/java/com/axway/apim/APIImportApp.java
+++ b/modules/api-import/src/main/java/com/axway/apim/APIImportApp.java
@@ -85,6 +85,7 @@ public class APIImportApp implements APIMCLIServiceProvider {
 					.includeQuotas(desiredAPI.getApplicationQuota()!=null) // and Quotas if not given in the Desired-API
 					.includeClientApplications(true) // Client-Apps must be loaded in all cases
 					.useFilter(filters)
+					.useAPIProxyAPIDefinition(params.isUseAPIProxyAPIDefinition()) // Should API-Definition load from the FE-API?
 					.build();
 			API actualAPI = apimAdapter.apiAdapter.getAPI(filter, true);
 			APIChangeState changes = new APIChangeState(actualAPI, desiredAPI);

--- a/modules/api-import/src/main/java/com/axway/apim/APIImportApp.java
+++ b/modules/api-import/src/main/java/com/axway/apim/APIImportApp.java
@@ -85,7 +85,7 @@ public class APIImportApp implements APIMCLIServiceProvider {
 					.includeQuotas(desiredAPI.getApplicationQuota()!=null) // and Quotas if not given in the Desired-API
 					.includeClientApplications(true) // Client-Apps must be loaded in all cases
 					.useFilter(filters)
-					.useAPIProxyAPIDefinition(params.isUseAPIProxyAPIDefinition()) // Should API-Definition load from the FE-API?
+					.useFEAPIDefinition(params.isUseFEAPIDefinition()) // Should API-Definition load from the FE-API?
 					.build();
 			API actualAPI = apimAdapter.apiAdapter.getAPI(filter, true);
 			APIChangeState changes = new APIChangeState(actualAPI, desiredAPI);

--- a/modules/api-import/src/main/java/com/axway/apim/apiimport/lib/APIImportCLIOptions.java
+++ b/modules/api-import/src/main/java/com/axway/apim/apiimport/lib/APIImportCLIOptions.java
@@ -35,7 +35,7 @@ public class APIImportCLIOptions extends APIMCoreCLIOptions {
 		option.setRequired(false);
 		options.addOption(option);
 		
-		option = new Option("useAPIProxyAPIDefinition", "If this flag is set, the Actual-API contains the API-Definition (e.g. Swagger) from the FE-API instead of the original imported API.");
+		option = new Option("useFEAPIDefinition", "If this flag is set, the Actual-API contains the API-Definition (e.g. Swagger) from the FE-API instead of the original imported API.");
 		option.setRequired(false);
 		options.addOption(option);
 		

--- a/modules/api-import/src/main/java/com/axway/apim/apiimport/lib/APIImportCLIOptions.java
+++ b/modules/api-import/src/main/java/com/axway/apim/apiimport/lib/APIImportCLIOptions.java
@@ -35,6 +35,10 @@ public class APIImportCLIOptions extends APIMCoreCLIOptions {
 		option.setRequired(false);
 		options.addOption(option);
 		
+		option = new Option("useAPIProxyAPIDefinition", "If this flag is set, the Actual-API contains the API-Definition (e.g. Swagger) from the FE-API instead of the original imported API.");
+		option.setRequired(false);
+		options.addOption(option);
+		
 		option = new Option("clientOrgsMode", true, "Controls how configured Client-Organizations are treated. Defaults to add!");
 		option.setArgName("ignore|replace|add");
 		options.addOption(option);
@@ -57,7 +61,7 @@ public class APIImportCLIOptions extends APIMCoreCLIOptions {
 		option.setArgName("true");
 		internalOptions.addOption(option);
 		
-		option = new Option("changeOrganization", "Set this flag to true to allow to change the organization of an existing API. Default is false.");
+		option = new Option("changeOrganization", "Set this flag to allow to change the organization of an existing API.");
 		option.setRequired(false);
 		internalOptions.addOption(option);
 		

--- a/modules/api-import/src/main/java/com/axway/apim/apiimport/lib/APIImportParams.java
+++ b/modules/api-import/src/main/java/com/axway/apim/apiimport/lib/APIImportParams.java
@@ -22,8 +22,8 @@ public class APIImportParams extends CommandParameters {
 		return true;
 	}
 	
-	public boolean isUseAPIProxyAPIDefinition() {
-		if(getValue("useAPIProxyAPIDefinition")==null) return false;
-		return Boolean.parseBoolean(getValue("useAPIProxyAPIDefinition"));
+	public boolean isUseFEAPIDefinition() {
+		if(getValue("useFEAPIDefinition")==null) return false;
+		return Boolean.parseBoolean(getValue("useFEAPIDefinition"));
 	}
 }

--- a/modules/api-import/src/main/java/com/axway/apim/apiimport/lib/APIImportParams.java
+++ b/modules/api-import/src/main/java/com/axway/apim/apiimport/lib/APIImportParams.java
@@ -21,4 +21,9 @@ public class APIImportParams extends CommandParameters {
 		// For import action we ignore the cache in all cases!
 		return true;
 	}
+	
+	public boolean isUseAPIProxyAPIDefinition() {
+		if(getValue("useAPIProxyAPIDefinition")==null) return false;
+		return Boolean.parseBoolean(getValue("useAPIProxyAPIDefinition"));
+	}
 }

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIFilter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIFilter.java
@@ -85,7 +85,7 @@ public class APIFilter {
 	
 	private boolean includeOriginalAPIDefinition = false;
 	
-	private boolean useAPIProxyAPIDefinition = false;
+	private boolean useFEAPIDefinition = false;
 	
 	POLICY_TRANSLATION translatePolicyMode = POLICY_TRANSLATION.NONE;
 	
@@ -183,12 +183,12 @@ public class APIFilter {
 		this.includeOriginalAPIDefinition = includeOriginalAPIDefinition;
 	}
 
-	public boolean isUseAPIProxyAPIDefinition() {
-		return useAPIProxyAPIDefinition;
+	public boolean isUseFEAPIDefinition() {
+		return useFEAPIDefinition;
 	}
 
-	public void setUseAPIProxyAPIDefinition(boolean useAPIProxyAPIDefinition) {
-		this.useAPIProxyAPIDefinition = useAPIProxyAPIDefinition;
+	public void setUseFEAPIDefinition(boolean useFEAPIDefinition) {
+		this.useFEAPIDefinition = useFEAPIDefinition;
 	}
 
 	public String getApiPath() {
@@ -510,7 +510,7 @@ public class APIFilter {
 		
 		boolean includeOriginalAPIDefinition = false;
 		
-		boolean useAPIProxyAPIDefinition = false;
+		boolean useFEAPIDefinition = false;
 		
 		POLICY_TRANSLATION translatePolicyMode = POLICY_TRANSLATION.NONE;
 		
@@ -557,7 +557,7 @@ public class APIFilter {
 			apiFilter.setIncludeClientOrganizations(this.includeClientOrganizations);
 			apiFilter.setIncludeClientApplications(this.includeClientApplications);
 			apiFilter.setIncludeOriginalAPIDefinition(this.includeOriginalAPIDefinition);
-			apiFilter.setUseAPIProxyAPIDefinition(this.useAPIProxyAPIDefinition);
+			apiFilter.setUseFEAPIDefinition(this.useFEAPIDefinition);
 			apiFilter.setIncludeImage(this.includeImage);
 			apiFilter.setLoadBackendAPI(this.loadBackendAPI);
 			apiFilter.setState(this.state);
@@ -687,8 +687,8 @@ public class APIFilter {
 			return this;
 		}
 		
-		public Builder useAPIProxyAPIDefinition(boolean useAPIProxyAPIDefinition) {
-			this.useAPIProxyAPIDefinition = useAPIProxyAPIDefinition;
+		public Builder useFEAPIDefinition(boolean useFEAPIDefinition) {
+			this.useFEAPIDefinition = useFEAPIDefinition;
 			return this;
 		}
 		

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIFilter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIFilter.java
@@ -58,7 +58,7 @@ public class APIFilter {
 	private String backendBasepath;
 	
 	private String createdOn;
-	private String createdOnOp;
+	private FILTER_OP createdOnOp;
 	
 	private APIType type;
 	
@@ -73,7 +73,8 @@ public class APIFilter {
 	
 	private METHOD_TRANSLATION translateMethodMode = METHOD_TRANSLATION.NONE;
 	
-	private boolean useBackendAPI = false;
+	/** If true, the API is loaded from the apirepo endpoint instead of proxies */
+	private boolean loadBackendAPI = false;
 	
 	private boolean includeOperations = false;
 	private boolean includeQuotas = false;
@@ -83,6 +84,8 @@ public class APIFilter {
 	private boolean includeImage = false;
 	
 	private boolean includeOriginalAPIDefinition = false;
+	
+	private boolean useAPIProxyAPIDefinition = false;
 	
 	POLICY_TRANSLATION translatePolicyMode = POLICY_TRANSLATION.NONE;
 	
@@ -161,7 +164,7 @@ public class APIFilter {
 	}
 
 	public String getApiType() {
-		if(useBackendAPI) {
+		if(loadBackendAPI) {
 			return APIManagerAdapter.TYPE_BACK_END;
 		} else {
 			return APIManagerAdapter.TYPE_FRONT_END;
@@ -178,6 +181,14 @@ public class APIFilter {
 
 	public void setIncludeOriginalAPIDefinition(boolean includeOriginalAPIDefinition) {
 		this.includeOriginalAPIDefinition = includeOriginalAPIDefinition;
+	}
+
+	public boolean isUseAPIProxyAPIDefinition() {
+		return useAPIProxyAPIDefinition;
+	}
+
+	public void setUseAPIProxyAPIDefinition(boolean useAPIProxyAPIDefinition) {
+		this.useAPIProxyAPIDefinition = useAPIProxyAPIDefinition;
 	}
 
 	public String getApiPath() {
@@ -232,12 +243,12 @@ public class APIFilter {
 		this.translatePolicyMode = translatePolicyMode;
 	}
 
-	public boolean isUseBackendAPI() {
-		return useBackendAPI;
+	public boolean isLoadBackendAPI() {
+		return loadBackendAPI;
 	}
 
-	public void setUseBackendAPI(boolean useBackendAPI) {
-		this.useBackendAPI = useBackendAPI;
+	public void setLoadBackendAPI(boolean loadBackendAPI) {
+		this.loadBackendAPI = loadBackendAPI;
 	}
 
 	public boolean isIncludeOperations() {
@@ -331,17 +342,17 @@ public class APIFilter {
 	public void setCreatedOn(String createdOn, FILTER_OP op) {
 		if(createdOn==null) return;
 		this.createdOn = createdOn;
-		this.createdOnOp = createdOnOp;
+		this.createdOnOp = op;
 		filters.add(new BasicNameValuePair("field", "createdOn"));
 		filters.add(new BasicNameValuePair("op", op.name()));
-		filters.add(new BasicNameValuePair("value", createdOnOp));
+		filters.add(new BasicNameValuePair("value", createdOn));
 	}
 	
 	public String getCreatedOn() {
 		return createdOn;
 	}
 	
-	public String getCreatedOnOp() {
+	public FILTER_OP getCreatedOnOp() {
 		return createdOnOp;
 	}
 
@@ -380,7 +391,7 @@ public class APIFilter {
 			return "APIFilter [id=" + id + ", apiId=" + apiId + ", name=" + name + ", vhost=" + vhost + ", apiPath="
 					+ apiPath + ", queryStringVersion=" + queryStringVersion + ", state=" + state + ", customProperties="
 					+ customProperties + ", deprecated=" + deprecated + ", retired=" + retired + ", apiType=" + apiType
-					+ ", translateMethodMode=" + translateMethodMode + ", useBackendAPI=" + useBackendAPI
+					+ ", translateMethodMode=" + translateMethodMode + ", loadBackendAPI=" + loadBackendAPI
 					+ ", includeOperations=" + includeOperations + ", includeQuotas=" + includeQuotas
 					+ ", includeClientOrganizations=" + includeClientOrganizations + ", includeClientApplications="
 					+ includeClientApplications + ", includeImage=" + includeImage + ", includeOriginalAPIDefinition="
@@ -389,7 +400,7 @@ public class APIFilter {
 		} else if(LOG.isDebugEnabled()) {
 			return "APIFilter [id=" + id + ", name=" + name + ", vhost=" + vhost + ", apiPath=" + apiPath
 					+ ", queryStringVersion=" + queryStringVersion + ", state=" + state + ", deprecated=" + deprecated
-					+ ", retired=" + retired + ", useBackendAPI=" + useBackendAPI + "]";
+					+ ", retired=" + retired + ", loadBackendAPI=" + loadBackendAPI + "]";
 		} else {
 			return "APIFilter [id=" + id + ", name=" + name + ", vhost=" + vhost + ", apiPath=" + apiPath
 					+ ", queryStringVersion=" + queryStringVersion + "]";			
@@ -488,7 +499,7 @@ public class APIFilter {
 		
 		METHOD_TRANSLATION translateMethodMode = METHOD_TRANSLATION.NONE;
 		
-		boolean useBackendAPI = false;
+		boolean loadBackendAPI = false;
 		
 		boolean includeOperations = false;
 		boolean includeQuotas = false;
@@ -498,6 +509,8 @@ public class APIFilter {
 		boolean includeImage = false;
 		
 		boolean includeOriginalAPIDefinition = false;
+		
+		boolean useAPIProxyAPIDefinition = false;
 		
 		POLICY_TRANSLATION translatePolicyMode = POLICY_TRANSLATION.NONE;
 		
@@ -518,13 +531,13 @@ public class APIFilter {
 		/**
 		 * Creates a ClientAppAdapter based on the provided configuration using all registered Adapters
 		 * @param type of the APIFilter
-		 * @param useBackendAPI is search backendEndAPI if set to true 
+		 * @param loadBackendAPI is search backendEndAPI if set to true 
 		 */
-		public Builder(APIType type, boolean useBackendAPI) {
+		public Builder(APIType type, boolean loadBackendAPI) {
 			super();
 			initType(type);
 			this.apiType = type;
-			this.useBackendAPI = useBackendAPI;
+			this.loadBackendAPI = loadBackendAPI;
 		}
 		
 		public APIFilter build() {
@@ -544,8 +557,9 @@ public class APIFilter {
 			apiFilter.setIncludeClientOrganizations(this.includeClientOrganizations);
 			apiFilter.setIncludeClientApplications(this.includeClientApplications);
 			apiFilter.setIncludeOriginalAPIDefinition(this.includeOriginalAPIDefinition);
+			apiFilter.setUseAPIProxyAPIDefinition(this.useAPIProxyAPIDefinition);
 			apiFilter.setIncludeImage(this.includeImage);
-			apiFilter.setUseBackendAPI(this.useBackendAPI);
+			apiFilter.setLoadBackendAPI(this.loadBackendAPI);
 			apiFilter.setState(this.state);
 			apiFilter.setRetired(this.retired);
 			apiFilter.setDeprecated(this.deprecated);
@@ -672,6 +686,12 @@ public class APIFilter {
 			this.includeOriginalAPIDefinition = includeOriginalAPIDefinition;
 			return this;
 		}
+		
+		public Builder useAPIProxyAPIDefinition(boolean useAPIProxyAPIDefinition) {
+			this.useAPIProxyAPIDefinition = useAPIProxyAPIDefinition;
+			return this;
+		}
+		
 		
 		public Builder includeImage(boolean includeImage) {
 			this.includeImage = includeImage;

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAccessAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAccessAdapter.java
@@ -181,9 +181,9 @@ public class APIManagerAPIAccessAdapter {
 			RestAPICall request = new POSTRequest(entity, uri, APIManagerAdapter.hasAdminAccount());
 			request.setContentType("application/json");
 			httpResponse = request.execute();
-			int statusCode = httpResponse.getStatusLine().getStatusCode();			
+			int statusCode = httpResponse.getStatusLine().getStatusCode();
+			String response = EntityUtils.toString(httpResponse.getEntity());
 			if(statusCode < 200 || statusCode > 299){
-				String response = EntityUtils.toString(httpResponse.getEntity());
 				if(statusCode==403 && response.contains("Unknown API")) {
 					LOG.warn("Got unexpected error: 'Unknown API' while creating API-Access ... Try again in 1 second.");
 					Thread.sleep(1000);
@@ -197,8 +197,6 @@ public class APIManagerAPIAccessAdapter {
 					}
 				}
 			}
-			
-			String response = EntityUtils.toString(httpResponse.getEntity());
 			apiAccess =  mapper.readValue(response, APIAccess.class);
 			// Clean cache for this ID (App/Org) to force reload next time
 			removeFromCache(parentId, type);

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAccessAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAccessAdapter.java
@@ -195,6 +195,9 @@ public class APIManagerAPIAccessAdapter {
 					} else {
 						LOG.info("Successfully created API-Access on retry. Received Status-Code: " +statusCode );
 					}
+				} else {
+					LOG.error("Error creating/updating API Access: "+apiAccess+". Response-Code: "+statusCode+". Got response: '"+response+"'");
+					throw new AppException("Error creating/updating API Access. Response-Code: "+statusCode+"", ErrorCode.API_MANAGER_COMMUNICATION);
 				}
 			}
 			apiAccess =  mapper.readValue(response, APIAccess.class);

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -468,7 +468,7 @@ public class APIManagerAPIAdapter {
 		APISpecification apiDefinition;
 		HttpResponse httpResponse = null;
 		try {
-			if(filter.isUseAPIProxyAPIDefinition()) {
+			if(filter.isUseFEAPIDefinition()) {
 				uri = new URIBuilder(CommandParameters.getInstance().getAPIManagerURL()).setPath(RestAPICall.API_VERSION + "/discovery/swagger/api/id/"+api.getId())
 						.setParameter("swaggerVersion", "2.0").build();
 				LOG.debug("Loading API-Definition from FE-API: ");

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -465,13 +465,12 @@ public class APIManagerAPIAdapter {
 	private static void addOriginalAPIDefinitionFromAPIM(API api, APIFilter filter) throws AppException {
 		if(!filter.isIncludeOriginalAPIDefinition()) return;
 		URI uri;
-		///discovery/swagger/api/id/3595cdef-46b7-4326-b3f8-e7bbaa531e7a?swaggerVersion=2.0
 		APISpecification apiDefinition;
 		HttpResponse httpResponse = null;
 		try {
 			if(filter.isUseAPIProxyAPIDefinition()) {
-				uri = new URIBuilder(CommandParameters.getInstance().getAPIManagerURL()).setPath(RestAPICall.API_VERSION + "/discovery/swagger/api/id/"+api.getId()+"?swaggerVersion=2.0")
-						.setParameter("original", "true").build();
+				uri = new URIBuilder(CommandParameters.getInstance().getAPIManagerURL()).setPath(RestAPICall.API_VERSION + "/discovery/swagger/api/id/"+api.getId())
+						.setParameter("swaggerVersion", "2.0").build();
 				LOG.debug("Loading API-Definition from FE-API: ");
 			} else {
 				uri = new URIBuilder(CommandParameters.getInstance().getAPIManagerURL()).setPath(RestAPICall.API_VERSION + "/apirepo/"+api.getApiId()+"/download")

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -122,7 +122,7 @@ public class APIManagerAPIAdapter {
 				addClientOrganizations(api, filter.isIncludeClientOrganizations());
 				addClientApplications(api, filter);
 				addExistingClientAppQuotas(api, filter.isIncludeQuotas());
-				addOriginalAPIDefinitionFromAPIM(api, filter.isIncludeOriginalAPIDefinition());
+				addOriginalAPIDefinitionFromAPIM(api, filter);
 				addImageFromAPIM(api, filter.isIncludeImage());
 				if(logProgress && apis.size()>5) Utils.progressPercentage(i, apis.size(), "Loading "+apis.size()+" APIs");
 			}
@@ -462,14 +462,21 @@ public class APIManagerAPIAdapter {
 		}		
 	}
 	
-	private static void addOriginalAPIDefinitionFromAPIM(API api, boolean includeOriginalAPIDefinition) throws AppException {
-		if(!includeOriginalAPIDefinition) return;
+	private static void addOriginalAPIDefinitionFromAPIM(API api, APIFilter filter) throws AppException {
+		if(!filter.isIncludeOriginalAPIDefinition()) return;
 		URI uri;
+		///discovery/swagger/api/id/3595cdef-46b7-4326-b3f8-e7bbaa531e7a?swaggerVersion=2.0
 		APISpecification apiDefinition;
 		HttpResponse httpResponse = null;
 		try {
-			uri = new URIBuilder(CommandParameters.getInstance().getAPIManagerURL()).setPath(RestAPICall.API_VERSION + "/apirepo/"+api.getApiId()+"/download")
-					.setParameter("original", "true").build();
+			if(filter.isUseAPIProxyAPIDefinition()) {
+				uri = new URIBuilder(CommandParameters.getInstance().getAPIManagerURL()).setPath(RestAPICall.API_VERSION + "/discovery/swagger/api/id/"+api.getId()+"?swaggerVersion=2.0")
+						.setParameter("original", "true").build();
+				LOG.debug("Loading API-Definition from FE-API: ");
+			} else {
+				uri = new URIBuilder(CommandParameters.getInstance().getAPIManagerURL()).setPath(RestAPICall.API_VERSION + "/apirepo/"+api.getApiId()+"/download")
+						.setParameter("original", "true").build();
+			}
 			RestAPICall getRequest = new GETRequest(uri);
 			httpResponse=getRequest.execute();
 			String res = EntityUtils.toString(httpResponse.getEntity(),StandardCharsets.UTF_8);

--- a/modules/app-export/src/main/java/com/axway/apim/appexport/ApplicationExportApp.java
+++ b/modules/app-export/src/main/java/com/axway/apim/appexport/ApplicationExportApp.java
@@ -25,6 +25,7 @@ public class ApplicationExportApp implements APIMCLIServiceProvider {
 	private static Logger LOG = LoggerFactory.getLogger(ApplicationExportApp.class);
 
 	static ErrorCodeMapper errorCodeMapper = new ErrorCodeMapper();
+	static ErrorState errorState = ErrorState.getInstance();
 
 	@Override
 	public String getName() {
@@ -57,6 +58,16 @@ public class ApplicationExportApp implements APIMCLIServiceProvider {
 				return runExport(params, ExportImpl.JSON_EXPORTER);
 			default:
 				return runExport(params, ExportImpl.CONSOLE_EXPORTER);
+			}
+		} catch (AppException e) {
+			
+			if(errorState.hasError()) {
+				errorState.logErrorMessages(LOG);
+				if(errorState.isLogStackTrace()) LOG.error(e.getMessage(), e);
+				return new ErrorCodeMapper().getMapedErrorCode(errorState.getErrorCode()).getCode();
+			} else {
+				LOG.error(e.getMessage(), e);
+				return new ErrorCodeMapper().getMapedErrorCode(e.getErrorCode()).getCode();
 			}
 		} catch (Exception e) {
 			LOG.error(e.getMessage(), e);


### PR DESCRIPTION
To solve issue #4 a new flag has been added:
`-useFEAPIDefinition`
If this flag is set, the export API contains the API-Definition (e.g. Swagger) from the FE-API instead of the original imported API.