### PR TITLE
Don't Re-Create API if not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Search for APIs based on configured Inbound- and Outbound-Security (See issue [#86](https://github.com/Axway-API-Management-Plus/apim-cli/issues/86))
 - Added support for API-Manager Config/Alerts/Remote-Hosts (See issue [#68](https://github.com/Axway-API-Management-Plus/apim-cli/issues/68))
+- APIs now updated without Re-Creating them if possible (See issue [#95](https://github.com/Axway-API-Management-Plus/apim-cli/issues/95))
 
 ### Fixed
 - Avoid NPE during API-Export if custom-properties config is inconsistent (See issue [#90](https://github.com/Axway-API-Management-Plus/apim-cli/issues/90))

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/API.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/API.java
@@ -64,7 +64,7 @@ public class API {
 	@JsonIgnore
 	private boolean requestForAllOrgs = false;
 	
-	@APIPropertyAnnotation(isBreaking = true, writableStates = {})
+	@APIPropertyAnnotation(isBreaking = true, writableStates = {}, isRecreate = true)
 	protected APISpecification apiDefinition = null;
 
 	@APIPropertyAnnotation(isBreaking = true, writableStates = {API.STATE_UNPUBLISHED})

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/API.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/API.java
@@ -156,8 +156,7 @@ public class API {
 			writableStates = {API.STATE_UNPUBLISHED})
 	protected String apiRoutingKey = null;
 	
-	@APIPropertyAnnotation(isBreaking = false, 
-			writableStates = {})
+	@APIPropertyAnnotation(isBreaking = false, writableStates = {}, isRecreate = true)
 	@JsonDeserialize( using = OrganizationDeserializer.class)
 	@JsonAlias({"organizationId", "organization"}) // Alias to read Organization based on the id as given by the API-Manager
 	protected Organization organization = null;

--- a/modules/apim-adapter/src/main/java/com/axway/apim/lib/APIPropertyAnnotation.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/lib/APIPropertyAnnotation.java
@@ -9,7 +9,18 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD) //can use in method only.
 public @interface APIPropertyAnnotation {
 	
+	/**
+	 * Controls if an API-Property would potentially lead to a breaking change.
+	 * @return true, if the API property can break client applications.
+	 */
 	public boolean isBreaking() default false;
+	
+	/**
+	 * If set to true, a change to this API-Property will force the API to be re-created. 
+	 * For instance, when the OpenAPI/Swagger spec is changed.
+	 * @return true if a change to this API-Property must re-create the API. Defaults to false
+	 */
+	public boolean isRecreate() default false;
 	
 	/**
 	 * This property should be set to false for all properties, not managed directly by the API-Proxy endpoint. For instance 
@@ -20,8 +31,8 @@ public @interface APIPropertyAnnotation {
 	 */
 	public boolean copyProp() default true;
 	
+	/**
+	 * @return an Array of states this API property can be changed
+	 */
 	public String[] writableStates();
-	
-	public Class propHandler() default void.class;
-
 }

--- a/modules/apis/src/main/java/com/axway/apim/api/export/impl/APIChangeHandler.java
+++ b/modules/apis/src/main/java/com/axway/apim/api/export/impl/APIChangeHandler.java
@@ -75,7 +75,7 @@ public class APIChangeHandler extends APIResultHandler {
 		for(APIChangeState changeState : apisToChange) {
 			LOG.info("Apply changes for API: '" + changeState.getDesiredAPI().getName() +"'");
 			try {
-				importManager.applyChanges(changeState, true);
+				importManager.applyChanges(changeState, false);
 			} catch(Exception e) {
 				LOG.error("Error applying changes for API: " + changeState.getDesiredAPI().getName(), e);
 			}

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/APIImportManager.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/APIImportManager.java
@@ -54,10 +54,14 @@ public class APIImportManager {
 			recreate.execute(changeState);
 		} else {
 			if(!changeState.hasAnyChanges()) {
-				APIPropertiesExport.getInstance().setProperty("feApiId", changeState.getActualAPI().getId());
-				LOG.debug("BUT, no changes detected between Import- and API-Manager-API. Exiting now...");
-				error.setWarning("No changes detected between Import- and API-Manager-API: '" + changeState.getActualAPI().getName() + "' ("+changeState.getActualAPI().getId()+")", ErrorCode.NO_CHANGE, false);
-				throw new AppException("No changes detected between Import- and API-Manager-API", ErrorCode.NO_CHANGE);
+				if(forceUpdate) {
+					
+				} else {
+					APIPropertiesExport.getInstance().setProperty("feApiId", changeState.getActualAPI().getId());
+					LOG.debug("BUT, no changes detected between Import- and API-Manager-API. Exiting now...");
+					error.setWarning("No changes detected between Import- and API-Manager-API: '" + changeState.getActualAPI().getName() + "' ("+changeState.getActualAPI().getId()+")", ErrorCode.NO_CHANGE, false);
+					throw new AppException("No changes detected between Import- and API-Manager-API", ErrorCode.NO_CHANGE);
+				}
 			}
 			LOG.info("Recognized the following changes. Potentially Breaking: " + changeState.getBreakingChanges() + 
 					" plus Non-Breaking: " + changeState.getNonBreakingChanges());

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/actions/RepublishToUpdateAPI.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/actions/RepublishToUpdateAPI.java
@@ -1,0 +1,41 @@
+package com.axway.apim.apiimport.actions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.axway.apim.adapter.APIStatusManager;
+import com.axway.apim.api.API;
+import com.axway.apim.apiimport.APIChangeState;
+import com.axway.apim.lib.errorHandling.AppException;
+
+public class RepublishToUpdateAPI {
+	
+	static Logger LOG = LoggerFactory.getLogger(RepublishToUpdateAPI.class);
+
+	public void execute(APIChangeState changes) throws AppException {
+		
+		API actualAPI = changes.getActualAPI();
+		
+		// 1. Create BE- and FE-API (API-Proxy) / Including updating all belonging props!
+		// This also includes all CONFIGURED application subscriptions and client-orgs
+		// But not potentially existing Subscriptions or manually created Client-Orgs
+		LOG.info("Unpublish existing API for update: '"+actualAPI.getName()+"' (ID: "+actualAPI.getId()+")");
+		
+		String actualState = changes.getActualAPI().getState();
+		
+		// Make sure the API state is restored during updateExisting
+		if(!changes.getNonBreakingChanges().contains("state")) {
+			changes.getNonBreakingChanges().add("state");
+			changes.getDesiredAPI().setState(actualState);
+		}
+		
+		APIStatusManager statusManager = new APIStatusManager();
+		statusManager.update(actualAPI, API.STATE_UNPUBLISHED, true);
+		
+		UpdateExistingAPI updateExistingAPI = new UpdateExistingAPI();
+		updateExistingAPI.execute(changes);
+		
+		LOG.debug("Existing API successfully updated: '"+actualAPI.getName()+"' (ID: "+actualAPI.getId()+")");
+	}
+
+}

--- a/modules/apis/src/test/java/com/axway/apim/test/security/UnpublishedPublishedApiKeyTestIT.java
+++ b/modules/apis/src/test/java/com/axway/apim/test/security/UnpublishedPublishedApiKeyTestIT.java
@@ -65,23 +65,16 @@ public class UnpublishedPublishedApiKeyTestIT extends TestNGCitrusTestDesigner {
 		action(swaggerImport);
 		
 		echo("####### Validate the Security-Settings have been changed (without changing the API-ID) #######");
-		http().client("apiManager")
-			.send()
-			.get("/proxies/${apiId}")
-			.name("api")
-			.header("Content-Type", "application/json");
+		http().client("apiManager").send().get("/proxies/${apiId}").name("api").header("Content-Type", "application/json");
 
-		http().client("apiManager")
-			.receive()
-			.response(HttpStatus.OK)
-			.messageType(MessageType.JSON)
+		http().client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
 			.validate("$.[?(@.id=='${apiId}')].id", "${apiId}")
 			.validate("$.[?(@.id=='${apiId}')].securityProfiles[0].devices[0].properties.takeFrom", "${takeFrom}")
 			.validate("$.[?(@.id=='${apiId}')].securityProfiles[0].devices[0].properties.apiKeyFieldName", "${apiKeyFieldName}")
 			.validate("$.[?(@.id=='${apiId}')].securityProfiles[0].devices[0].properties.removeCredentialsOnSuccess", "${removeCredentialsOnSuccess}")
 			.validate("$.[?(@.id=='${apiId}')].state", "published");
 		
-		echo("####### Change some settings of the PUBLISHED API, which leads to a new API-ID #######");
+		echo("####### Change some settings of the PUBLISHED API - Handled with a Re-Publish action #######");
 		createVariable("apiKeyFieldName", "KeyId-Test-Published");
 		createVariable("takeFrom", "HEADER");
 		createVariable("removeCredentialsOnSuccess", "false");
@@ -93,28 +86,15 @@ public class UnpublishedPublishedApiKeyTestIT extends TestNGCitrusTestDesigner {
 		action(swaggerImport);
 		
 		echo("####### Validate the Security-Settings have been changed (without changing the API-ID) #######");
-		http().client("apiManager")
-			.send()
-			.get("/proxies")
-			.name("api")
-			.header("Content-Type", "application/json");
+		http().client("apiManager").send().get("/proxies").name("api").header("Content-Type", "application/json");
 
-		http().client("apiManager")
-			.receive()
-			.response(HttpStatus.OK)
-			.messageType(MessageType.JSON)
+		http().client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
 			.validate("$.[?(@.path=='${apiPath}')].name", "${apiName}")
 			.validate("$.[?(@.path=='${apiPath}')].state", "published")
 			.validate("$.[?(@.path=='${apiPath}')].securityProfiles[0].devices[0].type", "apiKey")
 			.validate("$.[?(@.path=='${apiPath}')].securityProfiles[0].devices[0].properties.takeFrom", "${takeFrom}")
 			.validate("$.[?(@.path=='${apiPath}')].securityProfiles[0].devices[0].properties.apiKeyFieldName", "${apiKeyFieldName}")
-			.validate("$.[?(@.path=='${apiPath}')].securityProfiles[0].devices[0].properties.removeCredentialsOnSuccess", "${removeCredentialsOnSuccess}")
-			.extractFromPayload("$.[?(@.path=='${apiPath}')].id", "newApiId")
-			.validate("$.[?(@.path=='${apiPath}')].id", "@assertThat(not(equalTo(${apiId})))@");
-		
-		echo("First API-ID: ${apiId}");
-		echo("New   API-ID: ${newApiId}");
-		
+			.validate("$.[?(@.path=='${apiPath}')].securityProfiles[0].devices[0].properties.removeCredentialsOnSuccess", "${removeCredentialsOnSuccess}");		
 	}
 
 }

--- a/modules/setup/pom.xml
+++ b/modules/setup/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.github.axway-api-management-plus.apim-cli</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.2.4-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
This PR adds a new RepublishToUpdateAPI action. Now this action is used instead of RecreateToUpdateAPI when no API-Property flagged as `ReCreate=true` is changed.

With that, an API is no longer Re-Created (incl. the BE) just to update the FE-API. Instead the FE-API is unpublished, changed and Re-Published:
```
0      INFO     APIManagerAdapter| Successfully connected to API-Manager (7.7.20200730) on: https://api-env:8075
252    INFO  IImportConfigAdapter| Reading API-Definition (Swagger/WSDL) from file: 'C:\Axway\Tools\apim-cli-1.3.0-SNAPSHOT\samples\petstore.json' (absolute path)
657    INFO  APIManagerAPIAdapter| Found existing API on path: '/sample/minimal/apidefinition/api/v1' (published) (ID: '20460086-ea61-40b6-b52e-7fe1a2b76aae'
666    INFO      APIImportManager| Recognized the following changes. Potentially Breaking: [] plus Non-Breaking: [version]
666    INFO      APIImportManager| Update API Strategy: Re-Publish API to apply changes
668    INFO  RepublishToUpdateAPI| Unpublish existing API for update: 'Sample Minimal API' (ID: 20460086-ea61-40b6-b52e-7fe1a2b76aae)
701    INFO     UpdateExistingAPI| Update existing unpublished API: 'Sample Minimal API' 1.2.0 (ID: 20460086-ea61-40b6-b52e-7fe1a2b76aae)
701    INFO        APIChangeState| Updating Frontend-API (Proxy) for the following properties: version
801    INFO     UpdateExistingAPI| Successfully updated published API: 'Sample Minimal API' 1.3.0 (ID: 20460086-ea61-40b6-b52e-7fe1a2b76aae)
802    INFO  RepublishToUpdateAPI| Existing API successfully updated: 'Sample Minimal API' (ID: 20460086-ea61-40b6-b52e-7fe1a2b76aae)
```

This closes issue #95 