### PR TITLE
Update apim.bat

### DIFF
--- a/modules/apim-cli/assembly/scripts/apim.bat
+++ b/modules/apim-cli/assembly/scripts/apim.bat
@@ -27,7 +27,7 @@ IF DEFINED AXWAY_APIM_CLI_HOME (
 )
 SET bkpClassPath=%CLASSPATH%
 
-CD "%programDir%"
+CD /D "%programDir%"
 SET CLASSPATH="%programDir%\lib";"%programDir%\conf"
 
 FOR /R ./lib %%a in (*.jar) DO CALL :AddToPath "%%a"


### PR DESCRIPTION
Fixes issue with classpath compilation when invoking apim.bat from a drive different from the apim-cli folder.