### PR TITLE
Restore application subscriptions, when API is Republished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Created BE-API response was parsing the response wrong. This could lead to an issue, if the API contains a createdOn field. (See issue [#112](https://github.com/Axway-API-Management-Plus/apim-cli/issues/112))
 - Unicode API-Name was not shown correctly in the Backend-API overview (See issue [#113](https://github.com/Axway-API-Management-Plus/apim-cli/issues/113))
+- Application-Subscription not restored, when API is Republished to be updated (See issue [#114](https://github.com/Axway-API-Management-Plus/apim-cli/issues/114))
 
 ## [1.3.0] 2020-11-10
 ### Added

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/actions/RepublishToUpdateAPI.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/actions/RepublishToUpdateAPI.java
@@ -1,11 +1,18 @@
 package com.axway.apim.apiimport.actions;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.axway.apim.adapter.APIStatusManager;
 import com.axway.apim.api.API;
+import com.axway.apim.api.model.Organization;
+import com.axway.apim.api.model.apps.ClientApplication;
 import com.axway.apim.apiimport.APIChangeState;
+import com.axway.apim.lib.CoreParameters;
+import com.axway.apim.lib.CoreParameters.Mode;
 import com.axway.apim.lib.errorHandling.AppException;
 
 public class RepublishToUpdateAPI {
@@ -15,6 +22,21 @@ public class RepublishToUpdateAPI {
 	public void execute(APIChangeState changes) throws AppException {
 		
 		API actualAPI = changes.getActualAPI();
+		
+		Mode clientAppsMode = CoreParameters.getInstance().getClientAppsMode();
+		Mode clientOrgsMode =  CoreParameters.getInstance().getClientOrgsMode();
+		// Get existing Orgs and Apps, as they will be lost when the API gets unpublished
+		if(clientAppsMode==Mode.add && actualAPI.getApplications()!=null) { 
+			changes.getDesiredAPI().getApplications().addAll(actualAPI.getApplications());
+			// Reset the applications to have them re-created 
+			actualAPI.setApplications(new ArrayList<ClientApplication>());
+		}
+		if(clientOrgsMode==Mode.add && actualAPI.getClientOrganizations()!=null) {
+			// Take over existing organizations
+			changes.getDesiredAPI().getClientOrganizations().addAll(actualAPI.getClientOrganizations());
+			// Delete them, so that they are re-created
+			actualAPI.setClientOrganizations(new ArrayList<Organization>());
+		}
 		
 		// 1. Create BE- and FE-API (API-Proxy) / Including updating all belonging props!
 		// This also includes all CONFIGURED application subscriptions and client-orgs

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/actions/RepublishToUpdateAPI.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/actions/RepublishToUpdateAPI.java
@@ -1,7 +1,6 @@
 package com.axway.apim.apiimport.actions;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,12 +25,12 @@ public class RepublishToUpdateAPI {
 		Mode clientAppsMode = CoreParameters.getInstance().getClientAppsMode();
 		Mode clientOrgsMode =  CoreParameters.getInstance().getClientOrgsMode();
 		// Get existing Orgs and Apps, as they will be lost when the API gets unpublished
-		if(clientAppsMode==Mode.add && actualAPI.getApplications()!=null) { 
+		if(clientAppsMode==Mode.add && actualAPI.getApplications()!=null && changes.getDesiredAPI().getApplications()!=null) { 
 			changes.getDesiredAPI().getApplications().addAll(actualAPI.getApplications());
 			// Reset the applications to have them re-created 
 			actualAPI.setApplications(new ArrayList<ClientApplication>());
 		}
-		if(clientOrgsMode==Mode.add && actualAPI.getClientOrganizations()!=null) {
+		if(clientOrgsMode==Mode.add && actualAPI.getClientOrganizations()!=null && changes.getDesiredAPI().getClientOrganizations()!=null) {
 			// Take over existing organizations
 			changes.getDesiredAPI().getClientOrganizations().addAll(actualAPI.getClientOrganizations());
 			// Delete them, so that they are re-created

--- a/modules/apis/src/test/resources/com/axway/apim/test/files/applications/1_api-with-1-org-some-apps.json
+++ b/modules/apis/src/test/resources/com/axway/apim/test/files/applications/1_api-with-1-org-some-apps.json
@@ -2,7 +2,7 @@
    "name":"${apiName}",
    "path":"${apiPath}",
    "state":"${state}",
-   "version":"1.0.1",
+   "version":"${version}",
    "organization":"API Development ${orgNumber}",
    "clientOrganizations":[
       "${orgName2}" 


### PR DESCRIPTION
This PR fixes #114 
Now, existing Client-Applications and Organizations are Re-Created. This is handled by the RepublishToUpdateAPI Action class. An existing integration tests has been improved. Instead of testing with applications belonging to the same organization as the API, now 2 of the test-application belong to another organization. It's validated, that all organizations as before are granted to that API and that all applications still have a subscription.