### PR TITLE
Republish to update - Restore applications if nothing given in the API-Config

### DIFF
--- a/modules/apis/src/main/java/com/axway/apim/APIImportApp.java
+++ b/modules/apis/src/main/java/com/axway/apim/APIImportApp.java
@@ -92,7 +92,7 @@ public class APIImportApp implements APIMCLIServiceProvider {
 					.hasVHost(desiredAPI.getVhost())
 					.includeCustomProperties(desiredAPI.getCustomProperties())
 					.hasQueryStringVersion(desiredAPI.getApiRoutingKey())
-					.includeClientOrganizations(desiredAPI.getClientOrganizations()!=null) // For performance reasons don't load ClientOrgs
+					.includeClientOrganizations(true) // We have to load clientOrganization, in case they have to be taken over
 					.includeQuotas(desiredAPI.getApplicationQuota()!=null) // and Quotas if not given in the Desired-API
 					.includeClientApplications(true) // Client-Apps must be loaded in all cases
 					.useFilter(filters)

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/actions/ManageClientApps.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/actions/ManageClientApps.java
@@ -110,6 +110,7 @@ public class ManageClientApps {
 
 	private void createAppSubscription(List<ClientApplication> missingDesiredApps, String apiId) throws AppException {
 		if(missingDesiredApps.size()==0) return;
+		//List<ClientApplication> realMissingDesiredApps = missingDesiredApps.stream().distinct().collect(Collectors.toList());
 		LOG.info("Creating API-Access for the following apps: '"+missingDesiredApps.toString()+"'");
 		try {
 			for(ClientApplication app : missingDesiredApps) {

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/actions/ManageClientOrgs.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/actions/ManageClientOrgs.java
@@ -2,6 +2,7 @@ package com.axway.apim.apiimport.actions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import com.axway.apim.adapter.APIManagerAdapter;
 import com.axway.apim.api.API;
 import com.axway.apim.api.model.Organization;
+import com.axway.apim.api.model.apps.ClientApplication;
 import com.axway.apim.lib.CoreParameters;
 import com.axway.apim.lib.errorHandling.AppException;
 import com.axway.apim.lib.errorHandling.ErrorCode;

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/actions/RepublishToUpdateAPI.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/actions/RepublishToUpdateAPI.java
@@ -1,6 +1,7 @@
 package com.axway.apim.apiimport.actions;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,15 +26,17 @@ public class RepublishToUpdateAPI {
 		Mode clientAppsMode = CoreParameters.getInstance().getClientAppsMode();
 		Mode clientOrgsMode =  CoreParameters.getInstance().getClientOrgsMode();
 		// Get existing Orgs and Apps, as they will be lost when the API gets unpublished
-		if(clientAppsMode==Mode.add && actualAPI.getApplications()!=null && changes.getDesiredAPI().getApplications()!=null) { 
-			changes.getDesiredAPI().getApplications().addAll(actualAPI.getApplications());
-			// Reset the applications to have them re-created 
+		if(clientAppsMode==Mode.add && actualAPI.getApplications()!=null) { 
+			if(changes.getDesiredAPI().getApplications()==null) changes.getDesiredAPI().setApplications(new ArrayList<ClientApplication>());
+			mergeIntoList(changes.getDesiredAPI().getApplications(), actualAPI.getApplications());
+			// Reset the applications to have them re-created based the desired Apps
 			actualAPI.setApplications(new ArrayList<ClientApplication>());
 		}
-		if(clientOrgsMode==Mode.add && actualAPI.getClientOrganizations()!=null && changes.getDesiredAPI().getClientOrganizations()!=null) {
+		if(clientOrgsMode==Mode.add && actualAPI.getClientOrganizations()!=null) {
+			if(changes.getDesiredAPI().getClientOrganizations()==null) changes.getDesiredAPI().setClientOrganizations(new ArrayList<Organization>());
 			// Take over existing organizations
-			changes.getDesiredAPI().getClientOrganizations().addAll(actualAPI.getClientOrganizations());
-			// Delete them, so that they are re-created
+			mergeIntoList(changes.getDesiredAPI().getClientOrganizations(), actualAPI.getClientOrganizations());
+			// Delete them, so that they are re-created based on the desired orgs
 			actualAPI.setClientOrganizations(new ArrayList<Organization>());
 		}
 		
@@ -58,5 +61,13 @@ public class RepublishToUpdateAPI {
 		
 		LOG.debug("Existing API successfully updated: '"+actualAPI.getName()+"' (ID: "+actualAPI.getId()+")");
 	}
-
+	
+	private <T> List<T> mergeIntoList(List<T> targetList, List<T> source) {
+		for(T element : source) {
+			if(!targetList.contains(element)) {
+				targetList.add(element);
+			}
+		}
+		return targetList;
+	}
 }

--- a/modules/apis/src/test/java/com/axway/apim/test/applications/ApplicationSubscriptionTestIT.java
+++ b/modules/apis/src/test/java/com/axway/apim/test/applications/ApplicationSubscriptionTestIT.java
@@ -189,12 +189,45 @@ public class ApplicationSubscriptionTestIT extends TestNGCitrusTestRunner {
 		http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
 			.validate("$.*.apiId", "${apiId}"));
 		
+		echo("####### Slightly modify the API: '${apiName}' - Without applications given in the config and mode add (which is the default) (See issue: #117) #######");
+		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/basic/petstore.json");
+		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/basic/4_flexible-status-config.json");
+		createVariable("state", "published");
+		createVariable("orgName", "${orgName}");
+		createVariable("enforce", "true");
+		createVariable("version", "3.0.0");
+		createVariable("expectedReturnCode", "0");
+		swaggerImport.doExecute(context);
+		
+		echo("####### Validate previous application subscriptions have been restored after the API has been unpublished/updated/published #######");
+		
+		echo("####### Validate Application 3 still has an active subscription to the API (Based on the name) #######");
+		http(builder -> builder.client("apiManager").send().get("/applications/${consumingTestApp3Id}/apis").header("Content-Type", "application/json"));
+		
+		http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
+			.validate("$.*.apiId", "${apiId}"));
+		
+		echo("####### Validate Application 1 still has an active subscription to the API (based on the API-Key) #######");
+		http(builder -> builder.client("apiManager").send().get("/applications/${consumingTestApp1Id}/apis").header("Content-Type", "application/json"));
+		
+		http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
+			.validate("$.*.apiId", "${apiId}"));
+		
+		echo("####### Validate Application 2 still has an active subscription to the API (based on the Ext-Client-Id) #######");
+		http(builder -> builder.client("apiManager").send().get("/applications/${consumingTestApp2Id}/apis")
+			.header("Content-Type", "application/json"));
+		
+		http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
+			.validate("$.*.apiId", "${apiId}"));
+		
+		
 		echo("####### Re-Importing same API: '${apiName}' - Without applications subscriptions and mode replace #######");
 		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/basic/petstore.json");
 		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/basic/4_flexible-status-config.json");
 		createVariable("state", "published");
 		createVariable("orgName", "${orgName}");
 		createVariable("enforce", "true");
+		createVariable("version", "4.0.0");
 		createVariable("clientAppsMode", String.valueOf(Mode.replace));
 		createVariable("expectedReturnCode", "0");
 		swaggerImport.doExecute(context);

--- a/modules/apis/src/test/java/com/axway/apim/test/basic/BackToPublishedFromDeprecatedTestIT.java
+++ b/modules/apis/src/test/java/com/axway/apim/test/basic/BackToPublishedFromDeprecatedTestIT.java
@@ -42,6 +42,7 @@ public class BackToPublishedFromDeprecatedTestIT extends TestNGCitrusTestRunner 
 		createVariable("state", "published");
 		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/basic/4_flexible-status-config.json");
 		createVariable("expectedReturnCode", "0");
+		createVariable("version", "1.0.0");
 		swaggerImport.doExecute(context);
 		
 		echo("####### Validate API: '${apiName}' on path: '${apiPath}' with Status Published #######");

--- a/modules/apis/src/test/java/com/axway/apim/test/basic/ImportUnpublishedSetToPublishedAPITestIT.java
+++ b/modules/apis/src/test/java/com/axway/apim/test/basic/ImportUnpublishedSetToPublishedAPITestIT.java
@@ -36,6 +36,7 @@ public class ImportUnpublishedSetToPublishedAPITestIT extends TestNGCitrusTestRu
 		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/basic/4_flexible-status-config.json");
 		createVariable("state", "unpublished");
 		createVariable("expectedReturnCode", "0");
+		createVariable("version", "1.0.0");
 		swaggerImport.doExecute(context);
 		
 		echo("####### Validate API: '${apiName}' on path: '${apiPath}' has been imported #######");

--- a/modules/apis/src/test/java/com/axway/apim/test/basic/PublishedSubscribeUpgradeAPITestIT.java
+++ b/modules/apis/src/test/java/com/axway/apim/test/basic/PublishedSubscribeUpgradeAPITestIT.java
@@ -36,6 +36,7 @@ public class PublishedSubscribeUpgradeAPITestIT extends TestNGCitrusTestRunner {
 		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/basic/petstore.json");
 		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/basic/4_flexible-status-config.json");
 		createVariable("state", "published");
+		createVariable("version", "1.0.0");
 		createVariable("expectedReturnCode", "0");
 		swaggerImport.doExecute(context);
 

--- a/modules/apis/src/test/java/com/axway/apim/test/basic/UnpublishDeleteMustBeBreakingTestIT.java
+++ b/modules/apis/src/test/java/com/axway/apim/test/basic/UnpublishDeleteMustBeBreakingTestIT.java
@@ -34,6 +34,7 @@ public class UnpublishDeleteMustBeBreakingTestIT extends TestNGCitrusTestRunner 
 		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/basic/petstore.json");
 		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/basic/4_flexible-status-config.json");
 		createVariable("state", "published");
+		createVariable("version", "1.0.0");
 		createVariable("expectedReturnCode", "0");
 		swaggerImport.doExecute(context);
 		

--- a/modules/apis/src/test/java/com/axway/apim/test/basic/UnpublishedPublishedDeprecatedAPITestIT.java
+++ b/modules/apis/src/test/java/com/axway/apim/test/basic/UnpublishedPublishedDeprecatedAPITestIT.java
@@ -36,6 +36,7 @@ public class UnpublishedPublishedDeprecatedAPITestIT extends TestNGCitrusTestRun
 		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/basic/petstore.json");
 		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/basic/4_flexible-status-config.json");
 		createVariable("state", "unpublished");
+		createVariable("version", "1.0.0");
 		createVariable("expectedReturnCode", "0");
 		swaggerImport.doExecute(context);
 		

--- a/modules/apis/src/test/java/com/axway/apim/test/basic/UnpublishedSwaggerChangeTestIT.java
+++ b/modules/apis/src/test/java/com/axway/apim/test/basic/UnpublishedSwaggerChangeTestIT.java
@@ -36,6 +36,7 @@ public class UnpublishedSwaggerChangeTestIT extends TestNGCitrusTestRunner {
 		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/basic/petstore.json");
 		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/basic/4_flexible-status-config.json");
 		createVariable("state", "unpublished");
+		createVariable("version", "1.0.0");
 		createVariable("expectedReturnCode", "0");
 		swaggerImport.doExecute(context);
 

--- a/modules/apis/src/test/java/com/axway/apim/test/quota/DontOverwriteManualQuotaTestIT.java
+++ b/modules/apis/src/test/java/com/axway/apim/test/quota/DontOverwriteManualQuotaTestIT.java
@@ -47,6 +47,7 @@ public class DontOverwriteManualQuotaTestIT extends TestNGCitrusTestRunner {
 		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/basic/petstore.json");
 		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/basic/4_flexible-status-config.json");
 		createVariable("state", "unpublished");
+		createVariable("version", "1.0.0");
 		createVariable("expectedReturnCode", "0");
 		swaggerImport.doExecute(context);
 		

--- a/modules/apis/src/test/java/com/axway/apim/test/quota/QuotaModeReplaceTestIT.java
+++ b/modules/apis/src/test/java/com/axway/apim/test/quota/QuotaModeReplaceTestIT.java
@@ -39,6 +39,7 @@ public class QuotaModeReplaceTestIT extends TestNGCitrusTestRunner {
 		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/basic/petstore.json");
 		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/basic/4_flexible-status-config.json");
 		createVariable("state", "unpublished");
+		createVariable("version", "1.0.0");
 		createVariable("expectedReturnCode", "0");
 		swaggerImport.doExecute(context);
 		

--- a/modules/apis/src/test/resources/com/axway/apim/test/files/basic/4_flexible-status-config.json
+++ b/modules/apis/src/test/resources/com/axway/apim/test/files/basic/4_flexible-status-config.json
@@ -3,7 +3,7 @@
 	"name": "${apiName}",
 	"path": "${apiPath}",
 	"state": "${state}",
-	"version": "1.0.0",
+	"version": "${version}",
 	"organization": "API Development ${orgNumber}",
 	"inboundProfiles": {
 		"_default": {


### PR DESCRIPTION
Improved integration test to validate granted orgs and applications subscriptions are restored, when not given in the API-Config-File

Fix was basically to remove the check if `desiredAPI.getApplications()!=null`. Now they desiredApps are set to the actualApps. Same of organizations.

Additionally not avoid duplicates of applications and orgs.

Fixes #117 