### PR TITLE
Adds API-Upgrade feature to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - New API-Manager 7.7-September release settings are ignored during import (See issue [#119](https://github.com/Axway-API-Management-Plus/apim-cli/issues/119))
 
+### Added
+- Support to upgrade one or multiple APIs (See issue [#120](https://github.com/Axway-API-Management-Plus/apim-cli/issues/120))
+
 ## [1.3.2] 2020-11-25
 ### Fixed
-- Application-Subscription not restored, when API is Republished to be updated and no applications given the API-Config (See issue [#117](https://github.com/Axway-API-Management-Plus/apim-cli/issues/113))
+- Application-Subscription not restored, when API is Republished to be updated and no applications given the API-Config (See issue [#117](https://github.com/Axway-API-Management-Plus/apim-cli/issues/117))
 
 ## [1.3.1] 2020-11-24
 ### Fixed

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/API.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/API.java
@@ -22,7 +22,6 @@ import com.axway.apim.api.model.ServiceProfile;
 import com.axway.apim.api.model.TagMap;
 import com.axway.apim.api.model.apps.ClientApplication;
 import com.axway.apim.lib.APIPropertyAnnotation;
-import com.axway.apim.lib.errorHandling.AppException;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/modules/apis/src/main/java/com/axway/apim/APIExportApp.java
+++ b/modules/apis/src/main/java/com/axway/apim/APIExportApp.java
@@ -10,16 +10,17 @@ import com.axway.apim.adapter.apis.APIFilter;
 import com.axway.apim.api.API;
 import com.axway.apim.api.export.impl.APIResultHandler;
 import com.axway.apim.api.export.impl.APIResultHandler.APIListImpl;
-import com.axway.apim.api.export.lib.cli.CLIAPIApproveOptions;
 import com.axway.apim.api.export.lib.cli.CLIAPIDeleteOptions;
 import com.axway.apim.api.export.lib.cli.CLIAPIExportOptions;
 import com.axway.apim.api.export.lib.cli.CLIAPIUnpublishOptions;
+import com.axway.apim.api.export.lib.cli.CLIAPIUpgradeOptions;
 import com.axway.apim.api.export.lib.cli.CLIChangeAPIOptions;
-import com.axway.apim.api.export.lib.params.APIApproveParams;
 import com.axway.apim.api.export.lib.params.APIChangeParams;
 import com.axway.apim.api.export.lib.params.APIExportParams;
+import com.axway.apim.api.export.lib.params.APIUpgradeParams;
 import com.axway.apim.cli.APIMCLIServiceProvider;
 import com.axway.apim.cli.CLIServiceMethod;
+import com.axway.apim.lib.ExportResult;
 import com.axway.apim.lib.errorHandling.AppException;
 import com.axway.apim.lib.errorHandling.ErrorCode;
 import com.axway.apim.lib.errorHandling.ErrorCodeMapper;
@@ -33,6 +34,8 @@ import com.axway.apim.lib.utils.rest.APIMHttpClient;
 public class APIExportApp implements APIMCLIServiceProvider {
 
 	private static Logger LOG = LoggerFactory.getLogger(APIExportApp.class);
+	
+	static ErrorCodeMapper errorCodeMapper = new ErrorCodeMapper();
 	
 	private static ErrorState errorState = ErrorState.getInstance();
 
@@ -74,10 +77,10 @@ public class APIExportApp implements APIMCLIServiceProvider {
 			if(errorState.hasError()) {
 				errorState.logErrorMessages(LOG);
 				if(errorState.isLogStackTrace()) LOG.error(e.getMessage(), e);
-				return new ErrorCodeMapper().getMapedErrorCode(errorState.getErrorCode()).getCode();
+				return errorCodeMapper.getMapedErrorCode(errorState.getErrorCode()).getCode();
 			} else {
 				LOG.error(e.getMessage(), e);
-				return new ErrorCodeMapper().getMapedErrorCode(e.getErrorCode()).getCode();
+				return errorCodeMapper.getMapedErrorCode(e.getErrorCode()).getCode();
 			}
 		} catch (Exception e) {
 			LOG.error(e.getMessage(), e);
@@ -138,9 +141,25 @@ public class APIExportApp implements APIMCLIServiceProvider {
 		try {
 			deleteInstances();
 			
-			APIApproveParams params = (APIApproveParams) CLIAPIApproveOptions.create(args).getParams();
+			APIUpgradeParams params = (APIUpgradeParams) CLIAPIUpgradeOptions.create(args).getParams();
 			
 			return execute(params, APIListImpl.API_APPROVE_HANDLER);
+		} catch (Exception e) {
+			LOG.error(e.getMessage(), e);
+			return ErrorCode.UNXPECTED_ERROR.getCode();
+		}
+	}
+	
+	@CLIServiceMethod(name = "upgrade", description = "Upgrades one or more APIs based on a given 'old/reference' API.")
+	public static int upgrade(String args[]) {
+		try {
+			deleteInstances();
+			
+			APIUpgradeParams params = (APIUpgradeParams) CLIAPIUpgradeOptions.create(args).getParams();
+			
+			APIExportApp app = new APIExportApp();
+			ExportResult result = app.uprgradeAPI(params, APIListImpl.API_UPGRADE_HANDLE);
+			return result.getRc();
 		} catch (Exception e) {
 			LOG.error(e.getMessage(), e);
 			return ErrorCode.UNXPECTED_ERROR.getCode();
@@ -191,6 +210,64 @@ public class APIExportApp implements APIMCLIServiceProvider {
 
 			LOG.error(e.getMessage(), e);
 			return ErrorCode.UNXPECTED_ERROR.getCode();
+		}
+	}
+	
+	public ExportResult uprgradeAPI(APIUpgradeParams params, APIListImpl resultHandlerImpl) {
+		ExportResult result = new ExportResult();
+		try {
+			params.validateRequiredParameters();
+			// We need to clean some Singleton-Instances, as tests are running in the same JVM
+			APIManagerAdapter.deleteInstance();
+			ErrorState.deleteInstance();
+			APIMHttpClient.deleteInstances();
+			
+			APIManagerAdapter apimanagerAdapter = APIManagerAdapter.getInstance();
+			if(!APIManagerAdapter.hasAdminAccount()) {
+				LOG.error("Upgrading API-Access needs admin access.");
+				result.setRc(ErrorCode.NO_ADMIN_ROLE_USER.getCode());
+				return result;
+			}
+			// Get the reference API from API-Manager
+			API referenceAPI = apimanagerAdapter.apiAdapter.getAPI(params.getReferenceAPIFilter(), true);
+			if(referenceAPI == null) {
+				LOG.info("Published reference API for upgrade not found using filter: " + params.getReferenceAPIFilter());
+				return result;
+			}
+			params.setReferenceAPI(referenceAPI);
+			// Get all APIs to be upgraded
+			APIResultHandler resultHandler = APIResultHandler.create(resultHandlerImpl, params);
+			APIFilter filter = resultHandler.getFilter();
+			List<API> apis = apimanagerAdapter.apiAdapter.getAPIs(filter, true);
+
+			if(apis.size()==0) {
+				LOG.info("No published APIs found using filter: " + filter);
+			} else {
+				LOG.info(apis.size() + " API(s) selected.");
+				resultHandler.execute(apis);
+				if(resultHandler.hasError()) {
+					LOG.info("");
+					LOG.error("Please check the log. At least one error was recorded.");
+				} else {
+					LOG.debug("Successfully selected " + apis.size() + " API(s).");
+				}
+			}
+			return result;
+		} catch (AppException ap) { 
+			ErrorState errorState = ErrorState.getInstance();
+			if(errorState.hasError()) {
+				errorState.logErrorMessages(LOG);
+				if(errorState.isLogStackTrace()) LOG.error(ap.getMessage(), ap);
+				result.setRc(errorCodeMapper.getMapedErrorCode(errorState.getErrorCode()).getCode());
+			} else {
+				LOG.error(ap.getMessage(), ap);
+				result.setRc(errorCodeMapper.getMapedErrorCode(ap.getErrorCode()).getCode());
+			}
+			return result;
+		} catch (Exception e) {
+			LOG.error(e.getMessage(), e);
+			result.setRc(ErrorCode.UNXPECTED_ERROR.getCode());
+			return result;
 		}
 	}
 	

--- a/modules/apis/src/main/java/com/axway/apim/api/export/impl/APIResultHandler.java
+++ b/modules/apis/src/main/java/com/axway/apim/api/export/impl/APIResultHandler.java
@@ -22,7 +22,6 @@ import com.axway.apim.api.API;
 import com.axway.apim.api.export.ExportAPI;
 import com.axway.apim.api.export.lib.params.APIExportParams;
 import com.axway.apim.api.model.CustomProperties.Type;
-import com.axway.apim.api.model.CustomProperty;
 import com.axway.apim.api.model.DeviceType;
 import com.axway.apim.api.model.InboundProfile;
 import com.axway.apim.api.model.Organization;
@@ -49,7 +48,8 @@ public abstract class APIResultHandler {
 		API_PUBLISH_HANDLER(PublishAPIHandler.class),
 		API_UNPUBLISH_HANDLER(UnpublishAPIHandler.class), 
 		API_CHANGE_HANDLER(APIChangeHandler.class),
-		API_APPROVE_HANDLER(ApproveAPIHandler.class);
+		API_APPROVE_HANDLER(ApproveAPIHandler.class),
+		API_UPGRADE_HANDLE(UpgradeAPIHandler.class);
 		
 		private final Class<APIResultHandler> implClass;
 		

--- a/modules/apis/src/main/java/com/axway/apim/api/export/impl/UpgradeAPIHandler.java
+++ b/modules/apis/src/main/java/com/axway/apim/api/export/impl/UpgradeAPIHandler.java
@@ -1,0 +1,70 @@
+package com.axway.apim.api.export.impl;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import com.axway.apim.adapter.APIManagerAdapter;
+import com.axway.apim.adapter.apis.APIFilter;
+import com.axway.apim.adapter.apis.APIFilter.Builder;
+import com.axway.apim.api.API;
+import com.axway.apim.api.export.lib.params.APIExportParams;
+import com.axway.apim.api.export.lib.params.APIUpgradeParams;
+import com.axway.apim.lib.CoreParameters;
+import com.axway.apim.lib.errorHandling.AppException;
+import com.axway.apim.lib.errorHandling.ErrorCode;
+import com.axway.apim.lib.utils.Utils;
+
+public class UpgradeAPIHandler extends APIResultHandler {
+
+	public UpgradeAPIHandler(APIExportParams params) {
+		super(params);
+	}
+
+	@Override
+	public void execute(List<API> apis) throws AppException {
+		APIUpgradeParams upgradeParams = (APIUpgradeParams) params;
+		API referenceAPI = upgradeParams.getReferenceAPI();
+		if(referenceAPI == null) {
+			throw new AppException("Reference API for upgrade is missing.", ErrorCode.UNKNOWN_API);
+		}
+		System.out.println(apis.size() + " API(s) selected for upgrade based on reference/old API: "+referenceAPI.getName()+" "+referenceAPI.getVersion()+" ("+referenceAPI.getId()+").");		
+		System.out.println("Old/Reference API: deprecate: " + upgradeParams.getReferenceAPIDeprecate() + ", retired: " + upgradeParams.getReferenceAPIRetire() + ", retirementDate: " + getRetirementDate(upgradeParams.getReferenceAPIRetirementDate()));
+		if(CoreParameters.getInstance().isForce()) {
+			System.out.println("Force flag given to upgrade: "+apis.size()+" API(s)");
+		} else {
+			if(Utils.askYesNo("Do you wish to proceed? (Y/N)")) {
+			} else {
+				System.out.println("Canceled.");
+				return;
+			}
+		}
+		System.out.println("Okay, going to upgrade: " + apis.size() + " API(s) based on reference/old API: "+referenceAPI.getName()+" "+referenceAPI.getVersion()+" ("+referenceAPI.getId()+").");
+		for(API api : apis) {
+			try {
+				if(APIManagerAdapter.getInstance().apiAdapter.upgradeAccessToNewerAPI(api, referenceAPI, 
+						upgradeParams.getReferenceAPIDeprecate(), upgradeParams.getReferenceAPIRetire(), upgradeParams.getReferenceAPIRetirementDate())) {
+					LOG.info("API: "+api.getName()+" "+api.getVersion()+" ("+api.getId()+") successfully upgraded.");
+				}
+			} catch(Exception e) {
+				LOG.error("Error upgrading API: " + api.getName()+" "+api.getVersion()+" ("+api.getId()+") Error message: " + e.getMessage());
+			}
+		}
+		System.out.println("Done!");
+
+	}
+
+	@Override
+	public APIFilter getFilter() {
+		Builder builder = getBaseAPIFilterBuilder();
+		builder.hasState(API.STATE_PUBLISHED);
+		return builder.build();
+	}
+	
+	private String getRetirementDate(Long retirementDate) {
+		if(retirementDate == null) return "N/A";
+		Date retireDate = new Date(retirementDate);
+		return SimpleDateFormat.getDateInstance(SimpleDateFormat.SHORT).format(retireDate);
+	}
+
+}

--- a/modules/apis/src/main/java/com/axway/apim/api/export/lib/cli/CLIAPIUpgradeOptions.java
+++ b/modules/apis/src/main/java/com/axway/apim/api/export/lib/cli/CLIAPIUpgradeOptions.java
@@ -1,0 +1,97 @@
+package com.axway.apim.api.export.lib.cli;
+
+import org.apache.commons.cli.Option;
+
+import com.axway.apim.api.export.lib.params.APIUpgradeParams;
+import com.axway.apim.lib.CLIOptions;
+import com.axway.apim.lib.CoreCLIOptions;
+import com.axway.apim.lib.Parameters;
+import com.axway.apim.lib.errorHandling.AppException;
+
+public class CLIAPIUpgradeOptions extends CLIOptions {
+	
+	private CLIAPIUpgradeOptions(String[] args) {
+		super(args);
+	}
+	
+	public static CLIOptions create(String[] args) {
+		CLIOptions cliOptions = new CLIAPIUpgradeOptions(args);
+		cliOptions = new CLIAPIFilterOptions(cliOptions);
+		cliOptions = new CoreCLIOptions(cliOptions);
+		cliOptions.addOptions();
+		cliOptions.parse();
+		return cliOptions;
+	}
+	
+	@Override
+	public void addOptions() {
+		Option option = new Option("refAPIId", true, "Filter the reference API based on the ID.");
+		option.setRequired(false);
+		option.setArgName("UUID-ID-OF-THE-REF-API");
+		addOption(option);
+		
+		option = new Option("refAPIName", true, "Filter the reference API based on the name. Wildcards are supported.");
+		option.setRequired(false);
+		option.setArgName("*My-Old-API*");
+		addOption(option);
+		
+		option = new Option("refAPIVersion", true, "Filter the reference API based on the version.");
+		option.setRequired(false);
+		option.setArgName("1.0.0");
+		addOption(option);
+		
+		option = new Option("refAPIOrg", true, "Filter the reference API based on the organization. Wildcards are supported.");
+		option.setRequired(false);
+		option.setArgName("*Org A*");
+		addOption(option);
+		
+		option = new Option("refAPIDeprecate", true, "If set the old/reference API will be flagged as deprecated. Defaults to false.");
+		option.setRequired(false);
+		option.setArgName("true");
+		addOption(option);
+		
+		option = new Option("refAPIRetire", true, "If set the old/reference API will be retired. Default to false.");
+		option.setRequired(false);
+		option.setArgName("true");
+		addOption(option);
+		
+		option = new Option("refAPIRetireDate", true, "Sets the retirement date of the old API. Supported formats: \"dd.MM.yyyy\", \"dd/MM/yyyy\", \"yyyy-MM-dd\", \"dd-MM-yyyy\"");
+		option.setRequired(false);
+		option.setArgName("2021/06/30");
+		addOption(option);
+	}
+
+	@Override
+	public void printUsage(String message, String[] args) {
+		super.printUsage(message, args);		
+		System.out.println("----------------------------------------------------------------------------------------");
+		System.out.println("Upgrade one or more APIs based on the given reference API.");
+		System.out.println("App-Subscriptions and Granted orgs are taken over to all selected APIs based on the reference API.");
+		System.out.println("The reference API must be unique. APIs must be published to be considered.");
+		System.out.println(getBinaryName()+" api upgrade -s api-env -refAPIId <UUID-ID-OF-THE-REF-API> -id <UUID-ID-OF-THE-API>");
+		System.out.println(getBinaryName()+" api upgrade -s api-env -n \"*APIs-to-be-upgraded*\" -refAPIName \"*Name of Ref-API*\"");
+		System.out.println(getBinaryName()+" api upgrade -s api-env -n \"*APIs-to-be-upgraded*\" -refAPIName \"*Name of Ref-API*\" -refAPIDeprecate true");
+		System.out.println();
+		System.out.println();
+		System.out.println("For more information and advanced examples please visit:");
+		System.out.println("https://github.com/Axway-API-Management-Plus/apim-cli/wiki");
+	}
+
+	@Override
+	protected String getAppName() {
+		return getBinaryName()+" api approve";
+	}
+
+	@Override
+	public Parameters getParams() throws AppException {
+		APIUpgradeParams params = new APIUpgradeParams();
+		params.setReferenceAPIId(getValue("refAPIId"));
+		params.setReferenceAPIName(getValue("refAPIName"));
+		params.setReferenceAPIVersion(getValue("refAPIVersion"));
+		params.setReferenceAPIOrganization(getValue("refAPIOrg"));
+		params.setReferenceAPIDeprecate(Boolean.parseBoolean(getValue("refAPIDeprecate")));
+		params.setReferenceAPIRetire(Boolean.parseBoolean(getValue("refAPIRetire")));
+		params.setReferenceAPIRetirementDate(getValue("refAPIRetireDate"));
+		return params;
+	}
+}

--- a/modules/apis/src/main/java/com/axway/apim/api/export/lib/params/APIUpgradeParams.java
+++ b/modules/apis/src/main/java/com/axway/apim/api/export/lib/params/APIUpgradeParams.java
@@ -1,0 +1,91 @@
+package com.axway.apim.api.export.lib.params;
+
+import com.axway.apim.adapter.apis.APIFilter;
+import com.axway.apim.api.API;
+import com.axway.apim.lib.Parameters;
+import com.axway.apim.lib.errorHandling.AppException;
+import com.axway.apim.lib.errorHandling.ErrorCode;
+import com.axway.apim.lib.errorHandling.ErrorState;
+import com.axway.apim.lib.utils.Utils;
+
+public class APIUpgradeParams extends APIExportParams implements Parameters, APIFilterParams {
+	
+	private String referenceAPIId;
+	private String referenceAPIName;
+	private String referenceAPIVersion;
+	private String referenceAPIOrganization;
+	
+	private Boolean referenceAPIDeprecate = false;
+	private Boolean referenceAPIRetire = false;
+	private Long referenceAPIRetirementDate;
+	
+	private API referenceAPI;
+	
+	public API getReferenceAPI() {
+		return referenceAPI;
+	}
+	public void setReferenceAPI(API referenceAPI) {
+		this.referenceAPI = referenceAPI;
+	}
+	public Boolean getReferenceAPIDeprecate() {
+		return referenceAPIDeprecate;
+	}
+	public void setReferenceAPIDeprecate(Boolean referenceAPIDeprecate) {
+		this.referenceAPIDeprecate = referenceAPIDeprecate;
+	}
+	public Boolean getReferenceAPIRetire() {
+		return referenceAPIRetire;
+	}
+	public void setReferenceAPIRetire(Boolean referenceAPIRetire) {
+		this.referenceAPIRetire = referenceAPIRetire;
+	}
+	public Long getReferenceAPIRetirementDate() {
+		return referenceAPIRetirementDate;
+	}
+	public void setReferenceAPIRetirementDate(String referenceAPIRetirementDate) throws AppException {
+		if(referenceAPIRetirementDate == null) return;
+		this.referenceAPIRetirementDate = Utils.getParsedDate(referenceAPIRetirementDate);
+	}
+	public String getReferenceAPIId() {
+		return referenceAPIId;
+	}
+	public void setReferenceAPIId(String referenceAPIId) {
+		this.referenceAPIId = referenceAPIId;
+	}
+	public String getReferenceAPIName() {
+		return referenceAPIName;
+	}
+	public void setReferenceAPIName(String referenceAPIName) {
+		this.referenceAPIName = referenceAPIName;
+	}
+	public String getReferenceAPIVersion() {
+		return referenceAPIVersion;
+	}
+	public void setReferenceAPIVersion(String referenceAPIVersion) {
+		this.referenceAPIVersion = referenceAPIVersion;
+	}
+	public String getReferenceAPIOrganization() {
+		return referenceAPIOrganization;
+	}
+	public void setReferenceAPIOrganization(String referenceAPIOrganization) {
+		this.referenceAPIOrganization = referenceAPIOrganization;
+	}
+	
+	public APIFilter getReferenceAPIFilter() {
+		return new APIFilter.Builder()
+				.hasApiId(getReferenceAPIId())
+				.hasName(getReferenceAPIName())
+				.hasVHost(getReferenceAPIVersion())
+				.hasOrganization(getReferenceAPIOrganization())
+				.hasState(API.STATE_PUBLISHED)
+				.build();
+	}
+	@Override
+	public void validateRequiredParameters() throws AppException {
+		super.validateRequiredParameters();
+		if(getReferenceAPIRetire()!=null && getReferenceAPIRetirementDate()==null) {
+			ErrorState.getInstance().setError("If API should be retired, a retirement date is required.", ErrorCode.MISSING_PARAMETER, false);
+			throw new AppException("If API should be retired, a retirement date is required.", ErrorCode.MISSING_PARAMETER);
+		}
+	}
+}

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/DesiredAPI.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/DesiredAPI.java
@@ -1,14 +1,6 @@
 package com.axway.apim.apiimport;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.Date;
 import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,8 +9,7 @@ import com.axway.apim.api.API;
 import com.axway.apim.api.model.ServiceProfile;
 import com.axway.apim.lib.CoreParameters;
 import com.axway.apim.lib.errorHandling.AppException;
-import com.axway.apim.lib.errorHandling.ErrorCode;
-import com.axway.apim.lib.errorHandling.ErrorState;
+import com.axway.apim.lib.utils.Utils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -81,24 +72,6 @@ public class DesiredAPI extends API {
 	}
 	
 	public void setRetirementDate(String retirementDate) throws AppException {
-		List<String> dateFormats = Arrays.asList("dd.MM.yyyy", "dd/MM/yyyy", "yyyy-MM-dd", "dd-MM-yyyy");
-		SimpleDateFormat format;
-		Date retDate = null;
-		for (String dateFormat : dateFormats) {
-			format = new SimpleDateFormat(dateFormat, Locale.US);
-			format.setTimeZone(TimeZone.getTimeZone(ZoneId.of("Z")));
-			try {
-				retDate = format.parse(retirementDate);
-			} catch (ParseException e) { }
-			if(retDate!=null && retDate.after(new Date())) {
-				LOG.info("Parsed retirementDate: '"+retirementDate+"' using format: '"+dateFormat+"' to: '"+retDate+"'");
-				break;
-			}
-		}
-		if(retDate==null || retDate.before(new Date())) {
-			ErrorState.getInstance().setError("Unable to parse the given retirementDate using the following formats: " + dateFormats, ErrorCode.CANT_READ_CONFIG_FILE, false);
-			throw new AppException("Cannnot parse given retirementDate", ErrorCode.CANT_READ_CONFIG_FILE);
-		}
-		this.retirementDate = retDate.getTime();
+		this.retirementDate = Utils.getParsedDate(retirementDate);
 	}
 }

--- a/modules/apis/src/test/java/com/axway/apim/cli/APIExportCLIOptionsTest.java
+++ b/modules/apis/src/test/java/com/axway/apim/cli/APIExportCLIOptionsTest.java
@@ -8,7 +8,6 @@ import com.axway.apim.api.export.lib.cli.CLIAPIApproveOptions;
 import com.axway.apim.api.export.lib.cli.CLIAPIExportOptions;
 import com.axway.apim.api.export.lib.cli.CLIAPIUpgradeOptions;
 import com.axway.apim.api.export.lib.cli.CLIChangeAPIOptions;
-import com.axway.apim.api.export.lib.cli.CLINewChangeOptions;
 import com.axway.apim.api.export.lib.params.APIApproveParams;
 import com.axway.apim.api.export.lib.params.APIChangeParams;
 import com.axway.apim.api.export.lib.params.APIExportParams;
@@ -100,7 +99,7 @@ public class APIExportCLIOptionsTest {
 	
 	@Test
 	public void testUpgradeAPIParameters() throws ParseException, AppException {
-		String[] args = {"-s", "prod", "-a", "/api/v1/to/be/upgraded", "-refAPIID", "123456", "-refAPIName", "myRefOldAPI", "-refAPIVersion", "1.2.3", "-refAPIOrg", "RefOrg", "-refAPIDeprecate", "true", "-refAPIRetire", "true", "-refAPIRetireDate", "31.12.2021"};
+		String[] args = {"-s", "prod", "-a", "/api/v1/to/be/upgraded", "-refAPIId", "123456", "-refAPIName", "myRefOldAPI", "-refAPIVersion", "1.2.3", "-refAPIOrg", "RefOrg", "-refAPIDeprecate", "true", "-refAPIRetire", "true", "-refAPIRetireDate", "31.12.2021"};
 		CLIOptions cliOptions = CLIAPIUpgradeOptions.create(args);
 		APIUpgradeParams params = (APIUpgradeParams)cliOptions.getParams();
 		

--- a/modules/apis/src/test/java/com/axway/apim/cli/APIExportCLIOptionsTest.java
+++ b/modules/apis/src/test/java/com/axway/apim/cli/APIExportCLIOptionsTest.java
@@ -6,11 +6,13 @@ import org.testng.annotations.Test;
 
 import com.axway.apim.api.export.lib.cli.CLIAPIApproveOptions;
 import com.axway.apim.api.export.lib.cli.CLIAPIExportOptions;
+import com.axway.apim.api.export.lib.cli.CLIAPIUpgradeOptions;
 import com.axway.apim.api.export.lib.cli.CLIChangeAPIOptions;
 import com.axway.apim.api.export.lib.cli.CLINewChangeOptions;
 import com.axway.apim.api.export.lib.params.APIApproveParams;
 import com.axway.apim.api.export.lib.params.APIChangeParams;
 import com.axway.apim.api.export.lib.params.APIExportParams;
+import com.axway.apim.api.export.lib.params.APIUpgradeParams;
 import com.axway.apim.lib.CLIOptions;
 import com.axway.apim.lib.StandardExportParams.OutputFormat;
 import com.axway.apim.lib.StandardExportParams.Wide;
@@ -94,5 +96,35 @@ public class APIExportCLIOptionsTest {
 		Assert.assertEquals(params.getApiPath(), "/api/v1/greet");
 		
 		Assert.assertEquals(params.getPublishVhost(), "my.api-host.com");
+	}
+	
+	@Test
+	public void testUpgradeAPIParameters() throws ParseException, AppException {
+		String[] args = {"-s", "prod", "-a", "/api/v1/to/be/upgraded", "-refAPIID", "123456", "-refAPIName", "myRefOldAPI", "-refAPIVersion", "1.2.3", "-refAPIOrg", "RefOrg", "-refAPIDeprecate", "true", "-refAPIRetire", "true", "-refAPIRetireDate", "31.12.2021"};
+		CLIOptions cliOptions = CLIAPIUpgradeOptions.create(args);
+		APIUpgradeParams params = (APIUpgradeParams)cliOptions.getParams();
+		
+		// Validate core parameters are included
+		Assert.assertEquals(params.getUsername(), "apiadmin");
+		Assert.assertEquals(params.getPassword(), "changeme");
+		Assert.assertEquals(params.getHostname(), "api-env");
+		
+		// Validate an API-Filter parameters are included
+		Assert.assertEquals(params.getApiPath(), "/api/v1/to/be/upgraded");
+		
+		Assert.assertEquals(params.getReferenceAPIId(), "123456");
+		Assert.assertEquals(params.getReferenceAPIName(), "myRefOldAPI");
+		Assert.assertEquals(params.getReferenceAPIVersion(), "1.2.3");
+		Assert.assertEquals(params.getReferenceAPIOrganization(), "RefOrg");
+		Assert.assertTrue(params.getReferenceAPIRetire());
+		Assert.assertTrue(params.getReferenceAPIDeprecate());
+		Assert.assertTrue(params.getReferenceAPIRetirementDate() == Long.parseLong("1640908800000"));
+		
+		// Make sure, the default handling works for deprecate / and retire
+		String[] args2 = {"-s", "prod", "-a", "/api/v1/to/be/upgraded"};
+		cliOptions = CLIAPIUpgradeOptions.create(args2);
+		params = (APIUpgradeParams)cliOptions.getParams();
+		Assert.assertFalse(params.getReferenceAPIRetire());
+		Assert.assertFalse(params.getReferenceAPIDeprecate());
 	}
 }


### PR DESCRIPTION
Closes issue #120 by adding a new API-Upgrade feature to the CLI:

```
apim api upgrade -s api-env -n "*APIs-to-be-upgraded*" -refAPIName "*Name of Ref-API*"
apim api upgrade -s api-env -n "*APIs-to-be-upgraded*" -refAPIName "*Name of Ref-API*" -refAPIDeprecate true
```