### PR TITLE
Update apim.bat

### DIFF
--- a/modules/apim-cli/assembly/scripts/apim.bat
+++ b/modules/apim-cli/assembly/scripts/apim.bat
@@ -45,7 +45,7 @@ GOTO :END
 
 :OkClassPath
 
-CD "%currentDir%"
+CD /D "%currentDir%"
 
 %_java% -Xms64m -Xmx256m -Dlog4j.configuration=../lib/log4j.xml -classpath %CLASSPATH% com.axway.apim.cli.APIManagerCLI %*
 SET ERRNO=%ERRORLEVEL%


### PR DESCRIPTION
Switch back to current drive if CLI program directory is on a different drive. Fixes issue with relative paths not found during CLI execution.