### PR TITLE
implemented handling for app credentials that changed some attributes…

### DIFF
--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/model/apps/ClientAppCredential.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/model/apps/ClientAppCredential.java
@@ -7,11 +7,13 @@ import org.apache.commons.lang3.StringUtils;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@JsonIgnoreProperties(value = {"applicationId", "createdBy", "createdOn"})
 @JsonFilter("ClientAppCredentialFilter")
 public abstract class ClientAppCredential {
 	
 	String credentialType = null;
+	
+	String applicationId;
+	
 	String id;
 	
 	boolean enabled = true;
@@ -71,6 +73,14 @@ public abstract class ClientAppCredential {
 	public void setCorsOrigins(String[] corsOrigins) {
 		this.corsOrigins = corsOrigins;
 	}
+	
+	public String getApplicationId() {
+		return applicationId;
+	}
+
+	public void setApplicationId(String applicationId) {
+		this.applicationId = applicationId;
+	}
 
 	public abstract String getCredentialType();
 
@@ -86,5 +96,7 @@ public abstract class ClientAppCredential {
 					Arrays.equals(otherAppCredential.getCorsOrigins(), this.getCorsOrigins());
 		}
 		return false;
-	}	
+	}
+	
+	
 }

--- a/modules/apps/src/test/resources/com/axway/apim/appimport/apps/basic/CompleteApplication.json
+++ b/modules/apps/src/test/resources/com/axway/apim/appimport/apps/basic/CompleteApplication.json
@@ -11,7 +11,7 @@
     "credentialType" : "oauth",
     "enabled" : true,
     "secret" : "9cb76d80-1bc2-48d3-8d31-edeec0fddf6c",
-    "corsOrigins" : [ ],
+    "corsOrigins" : [ "${oauthCorsOrigins}"],
     "cert" : "app-oauth-cert.crt",
     "type" : "confidential",
     "clientId" : "ClientConfidentialApp-${appNumber}",
@@ -20,14 +20,14 @@
     "credentialType" : "apikeys",
     "enabled" : true,
     "secret" : "34f2b2d6-0334-4dcc-8442-e0e7009b8950",
-    "corsOrigins" : [ "*" ],
+    "corsOrigins" : [  "${oauthCorsOrigins}" ],
     "apiKey" : "6cd55c27-675a-444a-9bc7-ae9a7869184d-${appNumber}"
   } ,
   {
 	    "credentialType" : "extclients",
 	    "enabled" : true,
 	    "clientId" : "ClientConfidentialClientID-${appNumber}",
-		"corsOrigins" : [""]
+		"corsOrigins" : [ "${oauthCorsOrigins}"]
 	  } 
   ],
   "appQuota" : {


### PR DESCRIPTION
… (create or update) + automatic test


Hi @cwiechmann,
I noticed that during the import of applications a scenario wasn't implemented.

If I change some attributes in an already imported app credential (like client secret or corsOrigins) the apim-cli tool always tried to recreate the credential resource (oauth, extclients or apikey). With this pull request I tried to develop this scenario handling the creating or updating of the resource (if already exists).

Take a look and let me know