### PR TITLE
fix handling custom property changes in application import

### DIFF
--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/model/apps/ClientApplication.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/model/apps/ClientApplication.java
@@ -66,6 +66,8 @@ public class ClientApplication extends AbstractEntity implements CustomPropertie
 	private Organization organization;
 	
 	private Map<String, String> customProperties = null;
+	@JsonIgnore
+	private List<String> customPropertiesKeys = null;
 	
 	public String getOrganizationId() {
 		if(this.organization == null) return null;
@@ -178,6 +180,13 @@ public class ClientApplication extends AbstractEntity implements CustomPropertie
 	@JsonAnySetter
 	public void setCustomProperties(Map<String, String> customProperties) {
 		this.customProperties = customProperties;
+		if (this.customProperties!=null){
+			this.customPropertiesKeys=customProperties.keySet().stream().collect(Collectors.toList());
+		}
+	}
+
+	public List<String> getCustomPropertiesKeys() {
+		return customPropertiesKeys;
 	}
 
 	@Override

--- a/modules/apps/src/main/java/com/axway/apim/appimport/ClientApplicationImportApp.java
+++ b/modules/apps/src/main/java/com/axway/apim/appimport/ClientApplicationImportApp.java
@@ -77,13 +77,12 @@ public class ClientApplicationImportApp implements APIMCLIServiceProvider {
 			ClientAppImportManager importManager = new ClientAppImportManager(desiredAppsAdapter);
 			for(ClientApplication desiredApp : desiredApps) {
 				//I'm reading customProps from desiredApp, what if the desiredApp has no customProps and actualApp has many?
-				List<String> customProps = getCustomPropsFromDesiderdApp(desiredApp);
 				ClientApplication actualApp = APIManagerAdapter.getInstance().appAdapter.getApplication(new ClientAppFilter.Builder()
 						.includeCredentials(true)
 						.includeImage(true)
 						.includeQuotas(true)
 						.includeOauthResources(true)
-						.includeCustomProperties(customProps)
+						.includeCustomProperties(desiredApp.getCustomPropertiesKeys())
 						.hasName(desiredApp.getName())
 						.build());
 				importManager.setDesiredApp(desiredApp);
@@ -114,12 +113,6 @@ public class ClientApplicationImportApp implements APIMCLIServiceProvider {
 	public static void main(String args[]) { 
 		int rc = importApp(args);
 		System.exit(rc);
-	}
-	private List<String> getCustomPropsFromDesiderdApp(ClientApplication desiredApp) {
-		if (desiredApp.getCustomProperties()!=null){
-			return (List<String>)desiredApp.getCustomProperties().keySet().stream().collect(Collectors.toList());
-			}
-		return null;
 	}
 
 

--- a/modules/apps/src/main/java/com/axway/apim/appimport/ClientApplicationImportApp.java
+++ b/modules/apps/src/main/java/com/axway/apim/appimport/ClientApplicationImportApp.java
@@ -1,6 +1,7 @@
 package com.axway.apim.appimport;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,11 +76,14 @@ public class ClientApplicationImportApp implements APIMCLIServiceProvider {
 			List<ClientApplication> desiredApps = desiredAppsAdapter.getApplications();
 			ClientAppImportManager importManager = new ClientAppImportManager(desiredAppsAdapter);
 			for(ClientApplication desiredApp : desiredApps) {
+				//I'm reading customProps from desiredApp, what if the desiredApp has no customProps and actualApp has many?
+				List<String> customProps = getCustomPropsFromDesiderdApp(desiredApp);
 				ClientApplication actualApp = APIManagerAdapter.getInstance().appAdapter.getApplication(new ClientAppFilter.Builder()
 						.includeCredentials(true)
 						.includeImage(true)
 						.includeQuotas(true)
 						.includeOauthResources(true)
+						.includeCustomProperties(customProps)
 						.hasName(desiredApp.getName())
 						.build());
 				importManager.setDesiredApp(desiredApp);
@@ -111,5 +115,12 @@ public class ClientApplicationImportApp implements APIMCLIServiceProvider {
 		int rc = importApp(args);
 		System.exit(rc);
 	}
+	private List<String> getCustomPropsFromDesiderdApp(ClientApplication desiredApp) {
+		if (desiredApp.getCustomProperties()!=null){
+			return (List<String>)desiredApp.getCustomProperties().keySet().stream().collect(Collectors.toList());
+			}
+		return null;
+	}
+
 
 }

--- a/modules/apps/src/test/java/com/axway/apim/appimport/it/customProperties/ImportExportWithCustomPropsTestIT.java
+++ b/modules/apps/src/test/java/com/axway/apim/appimport/it/customProperties/ImportExportWithCustomPropsTestIT.java
@@ -86,6 +86,8 @@ public class ImportExportWithCustomPropsTestIT extends TestNGCitrusTestRunner im
 		createVariable(PARAM_EXPECTED_RC, "0");
 		variable("customProp2", "3");
 		importApp.doExecute(context);
+		echo("####### Validate application: '${appName}' - custom property has been changed #######");
+		http(builder -> builder.client("apiManager").send().get("/applications?field=name&op=eq&value=${appName}").header("Content-Type", "application/json"));
 		http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
 		  .validate("$.[?(@.name=='${appName}')].name", "@assertThat(hasSize(1))@")
 		  .validate("$.[?(@.name=='${appName}')].appCustomProperty1", "Custom value 1")

--- a/modules/apps/src/test/java/com/axway/apim/appimport/it/customProperties/ImportExportWithCustomPropsTestIT.java
+++ b/modules/apps/src/test/java/com/axway/apim/appimport/it/customProperties/ImportExportWithCustomPropsTestIT.java
@@ -37,10 +37,11 @@ public class ImportExportWithCustomPropsTestIT extends TestNGCitrusTestRunner im
 		ExportAppTestAction exportApp = new ExportAppTestAction(context);
 		
 		variable("appName", "My-Custom-Prop-App-"+importApp.getRandomNum());
-
+		variable("customProp2", "2");
 		echo("####### Import application: '${appName}' #######");		
 		createVariable(PARAM_CONFIGFILE,  PACKAGE + "AppWithCustomProperties.json");
 		createVariable(PARAM_EXPECTED_RC, "0");
+
 		importApp.doExecute(context);
 		
 		echo("####### Validate application: '${appName}' has been imported with Custom-Properties #######");
@@ -49,7 +50,7 @@ public class ImportExportWithCustomPropsTestIT extends TestNGCitrusTestRunner im
 		http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
 			.validate("$.[?(@.name=='${appName}')].name", "@assertThat(hasSize(1))@")
 			.validate("$.[?(@.name=='${appName}')].appCustomProperty1", "Custom value 1")
-			.validate("$.[?(@.name=='${appName}')].appCustomProperty2", "2")
+			.validate("$.[?(@.name=='${appName}')].appCustomProperty2", "${customProp2}")
 			.validate("$.[?(@.name=='${appName}')].appCustomProperty3", "true")
 			.extractFromPayload("$.[?(@.id=='${appName}')].id", "appId"));
 		
@@ -79,5 +80,18 @@ public class ImportExportWithCustomPropsTestIT extends TestNGCitrusTestRunner im
 		createVariable(PARAM_CONFIGFILE,  exportedConfig);
 		createVariable("expectedReturnCode", "10");
 		importApp.doExecute(context);
+
+		echo("####### Re-Import the exported application with changed custom prop #######");
+		createVariable(PARAM_CONFIGFILE,  PACKAGE + "AppWithCustomProperties.json");
+		createVariable(PARAM_EXPECTED_RC, "0");
+		variable("customProp2", "3");
+		importApp.doExecute(context);
+		http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
+		  .validate("$.[?(@.name=='${appName}')].name", "@assertThat(hasSize(1))@")
+		  .validate("$.[?(@.name=='${appName}')].appCustomProperty1", "Custom value 1")
+		  .validate("$.[?(@.name=='${appName}')].appCustomProperty2", "${customProp2}")
+		  .validate("$.[?(@.name=='${appName}')].appCustomProperty3", "true")
+		  .extractFromPayload("$.[?(@.id=='${appName}')].id", "appId"));
+
 	}
 }

--- a/modules/apps/src/test/resources/com/axway/apim/appimport/apps/customProperties/AppWithCustomProperties.json
+++ b/modules/apps/src/test/resources/com/axway/apim/appimport/apps/customProperties/AppWithCustomProperties.json
@@ -7,7 +7,7 @@
   "phone" : "654654646234",
   "customProperties": {
   	"appCustomProperty1": "Custom value 1",
-  	"appCustomProperty2": "2",
+  	"appCustomProperty2": "${customProp2}",
   	"appCustomProperty3": "true"  
   }
 }


### PR DESCRIPTION
hi @cwiechmann,
I noticed that a change in custom property in application entity is not detected by apim-cli.
From what I understand at the moment the actualApp loaded from Manager is not fetching any custom property.

This pull request try to address this problem

let me know what do you think

