### PR TITLE
Use getCanonicalFile to get Parent File

### DIFF
--- a/modules/apps/src/main/java/com/axway/apim/appimport/adapter/JSONConfigClientAppAdapter.java
+++ b/modules/apps/src/main/java/com/axway/apim/appimport/adapter/JSONConfigClientAppAdapter.java
@@ -91,8 +91,12 @@ public class JSONConfigClientAppAdapter extends ClientAppAdapter {
 		} catch (Exception e) {
 			throw new AppException("Cannot read organization(s) from config file: " + config, ErrorCode.ACCESS_ORGANIZATION_ERR, e);
 		}
-		addImage(apps, configFile.getParentFile());
-		addOAuthCertificate(apps, configFile.getParentFile());
+		try{
+			addImage(apps, configFile.getCanonicalFile().getParentFile());
+			addOAuthCertificate(apps, configFile.getCanonicalFile().getParentFile());
+		}catch (Exception e){
+			throw new AppException("Cannot read image/certificate for organization(s) from config file: " + config, ErrorCode.ACCESS_ORGANIZATION_ERR, e);
+		}		
 		addAPIAccess(apps, result);
 		validateCustomProperties(apps);
 		return;

--- a/modules/organizations/src/main/java/com/axway/apim/organization/adapter/JSONOrgAdapter.java
+++ b/modules/organizations/src/main/java/com/axway/apim/organization/adapter/JSONOrgAdapter.java
@@ -63,7 +63,11 @@ public class JSONOrgAdapter extends OrgAdapter {
 		} catch (Exception e) {
 			throw new AppException("Cannot read organization(s) from config file: " + config, ErrorCode.ACCESS_ORGANIZATION_ERR, e);
 		}
-		addImage(orgs, configFile.getParentFile());
+		try{
+			addImage(orgs, configFile.getCanonicalFile().getParentFile());
+		}catch (Exception e){
+			throw new AppException("Cannot read image for organization(s) from config file: " + config, ErrorCode.ACCESS_ORGANIZATION_ERR, e);
+		}
 		validateCustomProperties(orgs);
 		return;
 	}

--- a/modules/users/src/main/java/com/axway/apim/users/adapter/JSONUserAdapter.java
+++ b/modules/users/src/main/java/com/axway/apim/users/adapter/JSONUserAdapter.java
@@ -41,7 +41,11 @@ public class JSONUserAdapter extends UserAdapter {
 		} catch (Exception e) {
 			throw new AppException("Cannot read user(s) from config file: " + config, ErrorCode.UNKNOWN_USER, e);
 		}
-		addImage(users, configFile.getParentFile());
+		try{
+			addImage(users, configFile.getCanonicalFile().getParentFile());
+		}catch (Exception e){
+			throw new AppException("Cannot read image for user(s) from config file: " + config, ErrorCode.UNKNOWN_USER, e);
+		}
 		validateCustomProperties(users);
 		return true;
 	}


### PR DESCRIPTION
Use getCanonicalFile to get Parent File since getParentFile() will return null if config file is set without providing complete path.   
For example: -c config.json will fail since getParentFile() returns null