### PR TITLE
QuotaRestrictions refactored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Renamed log4j.xml into log4j2.xml
 
 ### Fixed
+- App-Export - AppQuota contains API-ID instead of API-Name (See issue [#145](https://github.com/Axway-API-Management-Plus/apim-cli/issues/145))
 - Outbound-AuthN OAuth-Provider-Profile only translated into FED-Name for _default profile (See issue [#246](https://github.com/Axway-API-Management-Plus/apim-cli/issues/246))
 - Backslashes in user passwords are ignored (See issue [#244](https://github.com/Axway-API-Management-Plus/apim-cli/issues/244))
 
 ### Added
 - Added support to delete applications from API-Manager
+- Added support for API-Method level quotas
 
 ## [1.6.1] 2021-12-20
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Outbound-AuthN OAuth-Provider-Profile only translated into FED-Name for _default profile (See issue [#246](https://github.com/Axway-API-Management-Plus/apim-cli/issues/246))
 - Backslashes in user passwords are ignored (See issue [#244](https://github.com/Axway-API-Management-Plus/apim-cli/issues/244))
 
+### Added
+- Added support to delete applications from API-Manager
+
 ## [1.6.1] 2021-12-20
 ### Security
 - Updated Apache Log4J from version 2.16.0 to 2.17.0 

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -943,9 +943,9 @@ public class APIManagerAPIAdapter {
 				// REST-API for App-Quota is also returning Default-Quotas, but we have to ignore them here!
 				if(app.getAppQuota().getId().equals(APIManagerAdapter.APPLICATION_DEFAULT_QUOTA) || app.getAppQuota().getId().equals(APIManagerAdapter.SYSTEM_API_QUOTA)) continue;
 				for(QuotaRestriction restriction : app.getAppQuota().getRestrictions()) {
-					if(restriction.getApi().equals(referenceAPI.getId())) { // This application has a restriction for this specific API
+					if(restriction.getApiId().equals(referenceAPI.getId())) { // This application has a restriction for this specific API
 						updateAppQuota = true;
-						restriction.setApi(apiToUpgradeAccess.getId()); // Take over the quota config to new API
+						restriction.setApiId(apiToUpgradeAccess.getId()); // Take over the quota config to new API
 						if(!restriction.getMethod().equals("*")) { // The restriction is for a specific method
 							String originalMethodName = APIManagerAdapter.getInstance().methodAdapter.getMethodForId(referenceAPI.getId(), restriction.getMethod()).getName();
 							// Try to find the same operation for the newly created API based on the name

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -413,8 +413,8 @@ public class APIManagerAPIAdapter {
 		APIQuota applicationQuota = null;
 		APIQuota sytemQuota = null;
 		try {
-			applicationQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(APIManagerQuotaAdapter.Quota.APPLICATION_DEFAULT.getQuotaId(), api.getId()); // Get the Application-Default-Quota
-			sytemQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(APIManagerQuotaAdapter.Quota.SYSTEM_DEFAULT.getQuotaId(), api.getId()); // Get the Application-Default-QuotagetQuotaFromAPIManager(); // Get the System-Default-Quota
+			applicationQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(APIManagerQuotaAdapter.Quota.APPLICATION_DEFAULT.getQuotaId(), api); // Get the Application-Default-Quota
+			sytemQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(APIManagerQuotaAdapter.Quota.SYSTEM_DEFAULT.getQuotaId(), api); // Get the Application-Default-QuotagetQuotaFromAPIManager(); // Get the System-Default-Quota
 			api.setApplicationQuota(applicationQuota);
 			api.setSystemQuota(sytemQuota);
 		} catch (AppException e) {

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -413,8 +413,8 @@ public class APIManagerAPIAdapter {
 		APIQuota applicationQuota = null;
 		APIQuota sytemQuota = null;
 		try {
-			applicationQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(APIManagerQuotaAdapter.Quota.APPLICATION_DEFAULT.getQuotaId(), api); // Get the Application-Default-Quota
-			sytemQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(APIManagerQuotaAdapter.Quota.SYSTEM_DEFAULT.getQuotaId(), api); // Get the Application-Default-QuotagetQuotaFromAPIManager(); // Get the System-Default-Quota
+			applicationQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(APIManagerQuotaAdapter.Quota.APPLICATION_DEFAULT.getQuotaId(), api, false); // Get the Application-Default-Quota
+			sytemQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(APIManagerQuotaAdapter.Quota.SYSTEM_DEFAULT.getQuotaId(), api, false); // Get the Application-Default-QuotagetQuotaFromAPIManager(); // Get the System-Default-Quota
 			api.setApplicationQuota(applicationQuota);
 			api.setSystemQuota(sytemQuota);
 		} catch (AppException e) {
@@ -428,7 +428,7 @@ public class APIManagerAPIAdapter {
 		if(!addQuota || !APIManagerAdapter.hasAdminAccount()) return;
 		if(api.getApplications()==null || api.getApplications().size()==0) return;
 		for(ClientApplication app : api.getApplications()) {
-			APIQuota appQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(app.getId(), null);
+			APIQuota appQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(app.getId(), null, true);
 			app.setAppQuota(appQuota);
 		}
 	}

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -957,7 +957,7 @@ public class APIManagerAPIAdapter {
 				if(updateAppQuota) {
 					LOG.info("Taking over existing quota config for application: '"+app.getName()+"' to newly created API.");
 					try {
-						FilterProvider filter = new SimpleFilterProvider().setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"apiId"}));
+						FilterProvider filter = new SimpleFilterProvider().setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"apiId", "apiName", "apiVersion", "apiPath", "vhost", "queryVersion"}));
 						mapper.setFilterProvider(filter);
 						uri = new URIBuilder(cmd.getAPIManagerURL()).setPath(cmd.getApiBasepath()+"/applications/"+app.getId()+"/quota").build();
 						entity = new StringEntity(mapper.writeValueAsString(app.getAppQuota()), ContentType.APPLICATION_JSON);

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -110,6 +110,8 @@ public class APIManagerAPIAdapter {
 	};
 
 	public APIManagerAPIAdapter() throws AppException {
+		FilterProvider filter = new SimpleFilterProvider().setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"apiId"}));
+		mapper.setFilterProvider(filter);
 	}
 
 	public List<API> getAPIs(APIFilter filter, boolean logProgress) throws AppException {

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -110,8 +110,6 @@ public class APIManagerAPIAdapter {
 	};
 
 	public APIManagerAPIAdapter() throws AppException {
-		FilterProvider filter = new SimpleFilterProvider().setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"apiId"}));
-		mapper.setFilterProvider(filter);
 	}
 
 	public List<API> getAPIs(APIFilter filter, boolean logProgress) throws AppException {
@@ -959,6 +957,8 @@ public class APIManagerAPIAdapter {
 				if(updateAppQuota) {
 					LOG.info("Taking over existing quota config for application: '"+app.getName()+"' to newly created API.");
 					try {
+						FilterProvider filter = new SimpleFilterProvider().setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"apiId"}));
+						mapper.setFilterProvider(filter);
 						uri = new URIBuilder(cmd.getAPIManagerURL()).setPath(cmd.getApiBasepath()+"/applications/"+app.getId()+"/quota").build();
 						entity = new StringEntity(mapper.writeValueAsString(app.getAppQuota()), ContentType.APPLICATION_JSON);
 						

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -413,8 +413,8 @@ public class APIManagerAPIAdapter {
 		APIQuota applicationQuota = null;
 		APIQuota sytemQuota = null;
 		try {
-			applicationQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(APIManagerQuotaAdapter.Quota.APPLICATION_DEFAULT.getQuotaId(), api, false); // Get the Application-Default-Quota
-			sytemQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(APIManagerQuotaAdapter.Quota.SYSTEM_DEFAULT.getQuotaId(), api, false); // Get the Application-Default-QuotagetQuotaFromAPIManager(); // Get the System-Default-Quota
+			applicationQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuota(APIManagerQuotaAdapter.Quota.APPLICATION_DEFAULT.getQuotaId(), api, false, false); // Get the Application-Default-Quota
+			sytemQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuota(APIManagerQuotaAdapter.Quota.SYSTEM_DEFAULT.getQuotaId(), api, false, false); // Get the Application-Default-QuotagetQuotaFromAPIManager(); // Get the System-Default-Quota
 			api.setApplicationQuota(applicationQuota);
 			api.setSystemQuota(sytemQuota);
 		} catch (AppException e) {
@@ -428,7 +428,7 @@ public class APIManagerAPIAdapter {
 		if(!addQuota || !APIManagerAdapter.hasAdminAccount()) return;
 		if(api.getApplications()==null || api.getApplications().size()==0) return;
 		for(ClientApplication app : api.getApplications()) {
-			APIQuota appQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(app.getId(), null, true);
+			APIQuota appQuota = APIManagerAdapter.getInstance().quotaAdapter.getQuota(app.getId(), null, true, true);
 			app.setAppQuota(appQuota);
 		}
 	}

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerQuotaAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerQuotaAdapter.java
@@ -161,7 +161,7 @@ public class APIManagerQuotaAdapter {
 		List<QuotaRestriction> apiRestrictions = new ArrayList<QuotaRestriction>();
 		try {
 			for(QuotaRestriction restriction : quotaConfig.getRestrictions()) {
-				if(restriction.getApi().equals(apiId)) {
+				if(restriction.getApiId().equals(apiId)) {
 					apiRestrictions.add(restriction);
 				}
 			}

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerQuotaAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerQuotaAdapter.java
@@ -21,6 +21,8 @@ import org.slf4j.LoggerFactory;
 
 import com.axway.apim.adapter.APIManagerAdapter;
 import com.axway.apim.adapter.APIManagerAdapter.CacheType;
+import com.axway.apim.adapter.jackson.QuotaRestrictionDeserializer;
+import com.axway.apim.adapter.jackson.QuotaRestrictionDeserializer.DeserializeMode;
 import com.axway.apim.api.model.APIQuota;
 import com.axway.apim.api.model.QuotaRestriction;
 import com.axway.apim.lib.CoreParameters;
@@ -30,6 +32,7 @@ import com.axway.apim.lib.utils.rest.GETRequest;
 import com.axway.apim.lib.utils.rest.PUTRequest;
 import com.axway.apim.lib.utils.rest.RestAPICall;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
@@ -60,7 +63,7 @@ public class APIManagerQuotaAdapter {
 	
 	Cache<String, String> applicationsQuotaCache;
 	
-	ObjectMapper mapper = APIManagerAdapter.mapper;
+	ObjectMapper mapper = new ObjectMapper();
 	
 	CoreParameters cmd = CoreParameters.getInstance();
 
@@ -111,6 +114,7 @@ public class APIManagerQuotaAdapter {
 		readQuotaFromAPIManager(quotaId);
 		APIQuota quotaConfig;
 		try {
+			mapper.registerModule(new SimpleModule().addDeserializer(QuotaRestriction.class, new QuotaRestrictionDeserializer(DeserializeMode.apiManagerData)));
 			quotaConfig = mapper.readValue(apiManagerResponse.get(quotaId), APIQuota.class);
 			if(apiId!=null)
 				quotaConfig = filterQuotaForAPI(quotaConfig, apiId);

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerQuotaAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerQuotaAdapter.java
@@ -116,7 +116,7 @@ public class APIManagerQuotaAdapter {
 	 * @param quotaId is either system or application default or a concrete quota ID
 	 * @param api is the quote for an API, then it can be passed here directly. This is then bound to the quote as restrictedAPI
 	 * @param addRestrictedAPI If false, then no effort is made to load the restricted api and bind it to the quote during deserialization. In this case the api should be passed. Defaults to true
-	 * @param ignoreSystemQuotas If true, then no quotas are returned with the flag: system: true
+	 * @param ignoreSystemQuotas If true, then no quotas are returned with the switch: system: true. This is useful if quotas for applications are requested and they should not contain application default quotas.
 	 * @return the configured quotas
 	 * @throws AppException is something goes wrong.
 	 */

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerQuotaAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerQuotaAdapter.java
@@ -110,12 +110,12 @@ public class APIManagerQuotaAdapter {
 		}
 	}
 	
-	public APIQuota getQuotaForAPI(String quotaId, API api) throws AppException {
+	public APIQuota getQuotaForAPI(String quotaId, API api, boolean addRestrictedAPI) throws AppException {
 		if(!APIManagerAdapter.hasAdminAccount()) return null;
 		readQuotaFromAPIManager(quotaId); // Quota-ID might be the System- or Application-Default Quota
 		APIQuota quotaConfig;
 		try {
-			mapper.registerModule(new SimpleModule().addDeserializer(QuotaRestriction.class, new QuotaRestrictionDeserializer(DeserializeMode.apiManagerData, false)));
+			mapper.registerModule(new SimpleModule().addDeserializer(QuotaRestriction.class, new QuotaRestrictionDeserializer(DeserializeMode.apiManagerData, addRestrictedAPI)));
 			quotaConfig = mapper.readValue(apiManagerResponse.get(quotaId), APIQuota.class);
 			if(api!=null) {
 				quotaConfig = filterQuotaForAPI(quotaConfig, api);

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerQuotaAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerQuotaAdapter.java
@@ -127,7 +127,7 @@ public class APIManagerQuotaAdapter {
 		HttpResponse httpResponse = null;
 		try {
 			uri = new URIBuilder(cmd.getAPIManagerURL()).setPath(cmd.getApiBasepath()+"/quotas/"+quotaId).build();
-			FilterProvider filter = new SimpleFilterProvider().setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"apiId"}));
+			FilterProvider filter = new SimpleFilterProvider().setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"apiId", "apiName", "apiVersion", "apiPath", "vhost", "queryVersion"}));
 			mapper.setFilterProvider(filter);
 			entity = new StringEntity(mapper.writeValueAsString(quotaConfig), ContentType.APPLICATION_JSON);
 			

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/clientApps/APIMgrAppsAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/clientApps/APIMgrAppsAdapter.java
@@ -573,6 +573,8 @@ public class APIMgrAppsAdapter {
 		HttpResponse httpResponse = null;
 		try {
 			URI uri = new URIBuilder(cmd.getAPIManagerURL()).setPath(cmd.getApiBasepath()+"/applications/"+app.getId()+"/quota").build();
+			FilterProvider filter = new SimpleFilterProvider().setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"apiId"}));
+			mapper.setFilterProvider(filter);
 			mapper.setSerializationInclusion(Include.NON_NULL);
 			String json = mapper.writeValueAsString(app.getAppQuota());
 			HttpEntity entity = new StringEntity(json, ContentType.APPLICATION_JSON);

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/clientApps/APIMgrAppsAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/clientApps/APIMgrAppsAdapter.java
@@ -573,7 +573,7 @@ public class APIMgrAppsAdapter {
 		HttpResponse httpResponse = null;
 		try {
 			URI uri = new URIBuilder(cmd.getAPIManagerURL()).setPath(cmd.getApiBasepath()+"/applications/"+app.getId()+"/quota").build();
-			FilterProvider filter = new SimpleFilterProvider().setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"apiId"}));
+			FilterProvider filter = new SimpleFilterProvider().setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"apiId", "apiName", "apiVersion", "apiPath", "vhost", "queryVersion"}));
 			mapper.setFilterProvider(filter);
 			mapper.setSerializationInclusion(Include.NON_NULL);
 			String json = mapper.writeValueAsString(app.getAppQuota());

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/clientApps/APIMgrAppsAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/clientApps/APIMgrAppsAdapter.java
@@ -29,6 +29,7 @@ import com.axway.apim.adapter.apis.APIManagerAPIAccessAdapter;
 import com.axway.apim.adapter.apis.APIManagerAPIAccessAdapter.Type;
 import com.axway.apim.api.model.APIAccess;
 import com.axway.apim.api.model.Image;
+import com.axway.apim.api.model.Organization;
 import com.axway.apim.api.model.User;
 import com.axway.apim.api.model.apps.APIKey;
 import com.axway.apim.api.model.apps.ApplicationPermission;
@@ -146,7 +147,7 @@ public class APIMgrAppsAdapter {
 				ClientApplication app = apps.get(i);
 				addImage(app, filter.isIncludeImage());
 				if(filter.isIncludeQuota()) {
-					app.setAppQuota(APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(app.getId(), null));
+					app.setAppQuota(APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(app.getId(), null, true));
 				}
 				addApplicationCredentials(app, filter.isIncludeCredentials());
 				addOauthResources(app,filter.isIncludeOauthResources());
@@ -843,6 +844,28 @@ public class APIMgrAppsAdapter {
 					((CloseableHttpResponse)httpResponse).close();
 				} catch (Exception ignore) { }
 			}
+		}
+	}
+	
+	public void deleteApplication(ClientApplication app) throws AppException {
+		HttpResponse httpResponse = null;
+		URI uri;
+		try {
+			uri = new URIBuilder(cmd.getAPIManagerURL()).setPath(cmd.getApiBasepath()+"/applications/"+app.getId()).build();
+			RestAPICall request = new DELRequest(uri, true);
+			httpResponse = request.execute();
+			int statusCode = httpResponse.getStatusLine().getStatusCode();
+			if(statusCode != 204){
+				LOG.error("Error deleting application. Response-Code: "+statusCode+". Got response: '"+EntityUtils.toString(httpResponse.getEntity())+"'");
+				throw new AppException("Error deleting application. Response-Code: "+statusCode+"", ErrorCode.API_MANAGER_COMMUNICATION);
+			}
+			LOG.info("Application: "+app.getName()+" ("+app.getId()+")" + " successfully deleted");
+		} catch (Exception e) {
+			throw new AppException("Error deleting application", ErrorCode.ACCESS_ORGANIZATION_ERR, e);
+		} finally {
+			try {
+				((CloseableHttpResponse)httpResponse).close();
+			} catch (Exception ignore) { }
 		}
 	}
 	

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/clientApps/APIMgrAppsAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/clientApps/APIMgrAppsAdapter.java
@@ -29,7 +29,6 @@ import com.axway.apim.adapter.apis.APIManagerAPIAccessAdapter;
 import com.axway.apim.adapter.apis.APIManagerAPIAccessAdapter.Type;
 import com.axway.apim.api.model.APIAccess;
 import com.axway.apim.api.model.Image;
-import com.axway.apim.api.model.Organization;
 import com.axway.apim.api.model.User;
 import com.axway.apim.api.model.apps.APIKey;
 import com.axway.apim.api.model.apps.ApplicationPermission;
@@ -147,7 +146,7 @@ public class APIMgrAppsAdapter {
 				ClientApplication app = apps.get(i);
 				addImage(app, filter.isIncludeImage());
 				if(filter.isIncludeQuota()) {
-					app.setAppQuota(APIManagerAdapter.getInstance().quotaAdapter.getQuotaForAPI(app.getId(), null, true));
+					app.setAppQuota(APIManagerAdapter.getInstance().quotaAdapter.getQuota(app.getId(), null, true, true));
 				}
 				addApplicationCredentials(app, filter.isIncludeCredentials());
 				addOauthResources(app,filter.isIncludeOauthResources());

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/QuotaRestrictionDeserializer.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/QuotaRestrictionDeserializer.java
@@ -1,4 +1,4 @@
-package com.axway.apim.api.model;
+package com.axway.apim.adapter.jackson;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -10,6 +10,8 @@ import com.axway.apim.adapter.APIManagerAdapter;
 import com.axway.apim.adapter.apis.APIFilter;
 import com.axway.apim.adapter.apis.APIManagerAPIAdapter;
 import com.axway.apim.api.API;
+import com.axway.apim.api.model.QuotaRestriction;
+import com.axway.apim.api.model.QuotaRestrictiontype;
 import com.axway.apim.lib.errorHandling.AppException;
 import com.axway.apim.lib.errorHandling.ErrorCode;
 import com.fasterxml.jackson.core.JsonParser;
@@ -76,8 +78,8 @@ public class QuotaRestrictionDeserializer extends JsonDeserializer<QuotaRestrict
 		if(node.has("apiPath")) { // Which might be given in the API-Config file
 			APIFilter apiFilter = new APIFilter.Builder().
 					hasApiPath(node.get("apiPath").asText()).
-					hasVHost(node.get("vhost").asText()).
-					hasQueryStringVersion(node.get("apiRoutingKey").asText()).
+					hasVHost(node.get("vhost")!=null ? node.get("vhost").asText() : null).
+					hasQueryStringVersion(node.get("apiRoutingKey")!=null ? node.get("apiRoutingKey").asText() : null).
 					build();
 			api = apiAdapter.getAPI(apiFilter, false);
 			if(api == null) {

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/QuotaRestrictionSerializer.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/QuotaRestrictionSerializer.java
@@ -2,6 +2,8 @@ package com.axway.apim.adapter.jackson;
 
 import java.io.IOException;
 
+import com.axway.apim.adapter.APIManagerAdapter;
+import com.axway.apim.api.model.APIMethod;
 import com.axway.apim.api.model.QuotaRestriction;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -25,15 +27,20 @@ public class QuotaRestrictionSerializer extends StdSerializer<QuotaRestriction> 
 		if(quotaRestriction.getRestrictedAPI()==null) {
 			jgen.writeObjectField("api", "*");
 			jgen.writeObjectField("method", "*");
-		} else {
+		} else { // API-Specific quota
 			jgen.writeObjectField("api", quotaRestriction.getRestrictedAPI().getName());
 			jgen.writeObjectField("apiPath", quotaRestriction.getRestrictedAPI().getPath());
-			jgen.writeObjectField("method", "*");
 			if(quotaRestriction.getRestrictedAPI().getVhost()!=null) {
 				jgen.writeObjectField("vhost", quotaRestriction.getRestrictedAPI().getVhost());
 			}
 			if(quotaRestriction.getRestrictedAPI().getApiRoutingKey()!=null) {
 				jgen.writeObjectField("apiRoutingKey", quotaRestriction.getRestrictedAPI().getApiRoutingKey());
+			}
+			if(quotaRestriction.getMethod()==null || "*".equals(quotaRestriction.getMethod())) {
+				jgen.writeObjectField("method", "*");
+			} else {
+				APIMethod method = APIManagerAdapter.getInstance().methodAdapter.getMethodForId(quotaRestriction.getApiId(), quotaRestriction.getMethod());
+				jgen.writeObjectField("method", method.getName());
 			}
 		}
 		jgen.writePOJOField("type",quotaRestriction.getType());

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/QuotaRestrictionSerializer.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/QuotaRestrictionSerializer.java
@@ -1,0 +1,47 @@
+package com.axway.apim.adapter.jackson;
+
+import java.io.IOException;
+
+import com.axway.apim.api.model.QuotaRestriction;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class QuotaRestrictionSerializer extends StdSerializer<QuotaRestriction> {
+	
+	private static final long serialVersionUID = 1L;
+
+	public QuotaRestrictionSerializer() {
+		this(null);
+	}
+	
+	public QuotaRestrictionSerializer(Class<QuotaRestriction> t) {
+		super(t);
+	}
+
+	@Override
+	public void serialize(QuotaRestriction quotaRestriction, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+		jgen.writeStartObject();
+		if(quotaRestriction.getRestrictedAPI()==null) {
+			jgen.writeObjectField("api", "*");
+			jgen.writeObjectField("method", "*");
+		} else {
+			jgen.writeObjectField("api", quotaRestriction.getRestrictedAPI().getName());
+			jgen.writeObjectField("apiPath", quotaRestriction.getRestrictedAPI().getPath());
+			jgen.writeObjectField("method", "*");
+			if(quotaRestriction.getRestrictedAPI().getVhost()!=null) {
+				jgen.writeObjectField("vhost", quotaRestriction.getRestrictedAPI().getVhost());
+			}
+			if(quotaRestriction.getRestrictedAPI().getApiRoutingKey()!=null) {
+				jgen.writeObjectField("apiRoutingKey", quotaRestriction.getRestrictedAPI().getApiRoutingKey());
+			}
+		}
+		jgen.writePOJOField("config",quotaRestriction.getConfig());
+		jgen.writeEndObject();
+	}
+	
+	@Override
+	public Class<QuotaRestriction> handledType() {
+		return QuotaRestriction.class;
+	}
+}

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/QuotaRestrictionSerializer.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/QuotaRestrictionSerializer.java
@@ -28,7 +28,8 @@ public class QuotaRestrictionSerializer extends StdSerializer<QuotaRestriction> 
 			jgen.writeObjectField("api", "*");
 			jgen.writeObjectField("method", "*");
 		} else { // API-Specific quota
-			jgen.writeObjectField("api", quotaRestriction.getRestrictedAPI().getName());
+			// Don't write the API-Name as it's confusing it is ignored during import when the API-Path is given.
+			// jgen.writeObjectField("api", quotaRestriction.getRestrictedAPI().getName());
 			jgen.writeObjectField("apiPath", quotaRestriction.getRestrictedAPI().getPath());
 			if(quotaRestriction.getRestrictedAPI().getVhost()!=null) {
 				jgen.writeObjectField("vhost", quotaRestriction.getRestrictedAPI().getVhost());

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/QuotaRestrictionSerializer.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/QuotaRestrictionSerializer.java
@@ -36,6 +36,7 @@ public class QuotaRestrictionSerializer extends StdSerializer<QuotaRestriction> 
 				jgen.writeObjectField("apiRoutingKey", quotaRestriction.getRestrictedAPI().getApiRoutingKey());
 			}
 		}
+		jgen.writePOJOField("type",quotaRestriction.getType());
 		jgen.writePOJOField("config",quotaRestriction.getConfig());
 		jgen.writeEndObject();
 	}

--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/StateSerializer.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/jackson/StateSerializer.java
@@ -1,7 +1,5 @@
 package com.axway.apim.adapter.jackson;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.axway.apim.api.API;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/model/APIQuota.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/model/APIQuota.java
@@ -15,7 +15,7 @@ public class APIQuota {
 	
 	String description;
 	
-	String system;
+	Boolean system;
 	
 	List<QuotaRestriction> restrictions;
 
@@ -59,11 +59,11 @@ public class APIQuota {
 		this.id = id;
 	}
 
-	public String getSystem() {
+	public Boolean getSystem() {
 		return system;
 	}
 
-	public void setSystem(String system) {
+	public void setSystem(Boolean system) {
 		this.system = system;
 	}
 	

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestriction.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestriction.java
@@ -5,7 +5,9 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonFilter;
 
+@JsonFilter("QuotaRestrictionFilter")
 public class QuotaRestriction {
 	@JsonAlias({"api"})
 	String apiId;
@@ -20,6 +22,10 @@ public class QuotaRestriction {
 
 	public void setApiId(String apiId) {
 		this.apiId = apiId;
+	}
+	
+	public String getApi() {
+		return apiId;
 	}
 
 	public String getMethod() {

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestriction.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestriction.java
@@ -4,19 +4,22 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+
 public class QuotaRestriction {
-	String api;
+	@JsonAlias({"api"})
+	String apiId;
 	String method;
 	QuotaRestrictiontype type;
 	
 	Map<String, String> config;
 
-	public String getApi() {
-		return api;
+	public String getApiId() {
+		return apiId;
 	}
 
-	public void setApi(String api) {
-		this.api = api;
+	public void setApiId(String apiId) {
+		this.apiId = apiId;
 	}
 
 	public String getMethod() {
@@ -47,7 +50,7 @@ public class QuotaRestriction {
 		if(otherRestriction == null) return false;
 		return 
 				StringUtils.equals(otherRestriction.getMethod(), this.getMethod()) &&
-				(ignoreAPI || StringUtils.equals(otherRestriction.getApi(), this.getApi() )) &&
+				(ignoreAPI || StringUtils.equals(otherRestriction.getApiId(), this.getApiId() )) &&
 				otherRestriction.getType()==this.getType() &&
 				StringUtils.equals(otherRestriction.getConfig().get("period"), this.getConfig().get("period")) &&
 				StringUtils.equals(otherRestriction.getConfig().get("per"), this.getConfig().get("per"));
@@ -69,6 +72,6 @@ public class QuotaRestriction {
 
 	@Override
 	public String toString() {
-		return "QuotaRestriction [api=" + api + ", method=" + method + ", type=" + type + ", config=" + config + "]";
+		return "QuotaRestriction [api=" + apiId + ", method=" + method + ", type=" + type + ", config=" + config + "]";
 	}
 }

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestriction.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestriction.java
@@ -4,14 +4,31 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.axway.apim.api.API;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @JsonFilter("QuotaRestrictionFilter")
 public class QuotaRestriction {
+	/**
+	 * Contains the ID of the API this restriction is applied to or a "*" if applied to all APIs. 
+	 * The JsonAlias is required for Deserialization as the API-Manager returns the information in field api
+	 */
 	@JsonAlias({"api"})
 	String apiId;
+	
+	/**
+	 * The API-Method either is the API-Method-ID or a "*" if applied to all API-Methods.
+	 */
 	String method;
+	
+	/**
+	 * The underlying API, if any, this restriction is applied too
+	 */
+	@JsonIgnore
+	API restrictedAPI;
+	
 	QuotaRestrictiontype type;
 	
 	Map<String, String> config;
@@ -24,8 +41,20 @@ public class QuotaRestriction {
 		this.apiId = apiId;
 	}
 	
+	/**
+	 * This getter is used when the Quota-Restriction is send to the API-Manager REST-API, which expects a field api
+	 * @return the ID of the API or a "*" if applied for all APIs.
+	 */
 	public String getApi() {
 		return apiId;
+	}
+
+	public API getRestrictedAPI() {
+		return restrictedAPI;
+	}
+
+	public void setRestrictedAPI(API restrictedAPI) {
+		this.restrictedAPI = restrictedAPI;
 	}
 
 	public String getMethod() {

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestrictionDeserializer.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestrictionDeserializer.java
@@ -52,7 +52,11 @@ public class QuotaRestrictionDeserializer extends JsonDeserializer<QuotaRestrict
 		String per = quotaConfig.get("per").asText();
 
 		QuotaRestriction restriction = new QuotaRestriction();
-		restriction.setType(QuotaRestrictiontype.valueOf(type));
+		try {
+			restriction.setType(QuotaRestrictiontype.valueOf(type));
+		} catch (IllegalArgumentException e) {
+			throw new AppException("Invalid quota config. The restriction type: " + type + " is invalid.", ErrorCode.INVALID_QUOTA_CONFIG);
+		}
 		restriction.setMethod(node.get("method").asText());
 		Map<String, String> configMap = new LinkedHashMap<String, String>();
 		configMap.put("period", period);

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestrictionDeserializer.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestrictionDeserializer.java
@@ -6,6 +6,10 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.axway.apim.adapter.APIManagerAdapter;
+import com.axway.apim.adapter.apis.APIFilter;
+import com.axway.apim.adapter.apis.APIManagerAPIAdapter;
+import com.axway.apim.api.API;
 import com.axway.apim.lib.errorHandling.AppException;
 import com.axway.apim.lib.errorHandling.ErrorCode;
 import com.fasterxml.jackson.core.JsonParser;
@@ -17,7 +21,23 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class QuotaRestrictionDeserializer extends JsonDeserializer<QuotaRestriction> {
 	
+	public enum DeserializeMode {apiManagerData, configFile};
+	
 	private final static String validPeriods = "month|week|day|hour|minute|second";
+	
+	private DeserializeMode desiralizeMode;
+	
+	APIManagerAPIAdapter apiAdapter;
+
+	public QuotaRestrictionDeserializer(DeserializeMode desirializeMode) {
+		super();
+		this.desiralizeMode = desirializeMode;
+		try {
+			this.apiAdapter = APIManagerAdapter.getInstance().apiAdapter;
+		} catch (AppException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
 	@SuppressWarnings("serial")
 	@Override
@@ -27,39 +47,90 @@ public class QuotaRestrictionDeserializer extends JsonDeserializer<QuotaRestrict
 		JsonNode node = oc.readTree(jp);
 		String type = node.get("type").asText();
 		JsonNode quotaConfig = node.get("config");
-		if(type.equals("throttlemb")) {
-			if(!quotaConfig.has("period") || !quotaConfig.has("per") || !quotaConfig.has("mb")) {
-				throw new AppException("Invalid quota config. For type 'throttlemb' the following configs are required: period, per, mb", ErrorCode.INVALID_QUOTA_CONFIG);
-			}
-		} else if(type.equals("throttle")) {
-			if(!quotaConfig.has("period") || !quotaConfig.has("per") || !quotaConfig.has("messages")) {
-				throw new AppException("Invalid quota config. For type 'throttle' the following configs are required: period, per, messages", ErrorCode.INVALID_QUOTA_CONFIG);
-			}
-		} else {
-			throw new AppException("Unsupported Quota-Type: '" + type + "'. Must be either: throttle or throttlemb", ErrorCode.INVALID_QUOTA_CONFIG);
-		}
+
 		String period = quotaConfig.get("period").asText();
 		String per = quotaConfig.get("per").asText();
-		Pattern pattern = Pattern.compile("^("+validPeriods+")$");
-		Matcher matcher = pattern.matcher(period);
-		if(!matcher.matches()) {
-			throw new AppException("Invalid quota period: '"+period+"'. Must be one of the following: "+validPeriods, ErrorCode.INVALID_QUOTA_CONFIG);
-		}
+
 		QuotaRestriction restriction = new QuotaRestriction();
 		restriction.setType(QuotaRestrictiontype.valueOf(type));
 		restriction.setMethod(node.get("method").asText());
 		Map<String, String> configMap = new LinkedHashMap<String, String>();
 		configMap.put("period", period);
 		configMap.put("per", per);
-		if(node.has("api")) {
-			restriction.setApiId(node.get("api").asText());
-		}
 		if(type.equals("throttle")) {
 			configMap.put("messages", quotaConfig.get("messages").asText());
 		} else {
 			configMap.put("mb", quotaConfig.get("mb").asText());
 		}
 		restriction.setConfig(configMap);
+		
+		// Set the API, if any, this quota should be applied too		
+		// Different options can be used to configure the API (See: #145)
+		
+		// If an API-Path is given, it takes precedence and the API-Name and API-Version is completely ignored
+		API api = null;
+		if(node.has("apiPath")) { // Which might be given in the API-Config file
+			APIFilter apiFilter = new APIFilter.Builder().
+					hasApiPath(node.get("apiPath").asText()).
+					hasVHost(node.get("vhost").asText()).
+					hasQueryStringVersion(node.get("apiRoutingKey").asText()).
+					build();
+			api = apiAdapter.getAPI(apiFilter, false);
+			if(api == null) {
+				throw new AppException("Invalid quota configuration. No API found using filter: '" + apiFilter + " (primary key: apiPath).", ErrorCode.INVALID_QUOTA_CONFIG);
+			}
+			restriction.setRestrictedAPI(api);
+			restriction.setApiId(api.getId());
+		// If no API-Path is given,
+		} else if(node.has("api")) { // Field api might contain the API-ID (From API-Manager), the API-Name or a Star if restriction should be applied to all APIs.
+			if("*".equals(node.get("api").asText())) {
+				restriction.setApiId("*");
+			} else {
+				// If data comes from API-Manager api contains the API-ID
+				if(desiralizeMode == DeserializeMode.apiManagerData) {
+					// api contains the ID of the API
+					api = APIManagerAdapter.getInstance().apiAdapter.getAPIWithId(node.get("api").asText());
+				// In the API-Config file the api contains the apiName
+				} else if (desiralizeMode == DeserializeMode.configFile) {
+					// If the apiPath is given, it takes precedence and the API-Name and API-Version is completely ignored
+					APIFilter apiFilter = new APIFilter.Builder().
+							hasName(node.get("api").asText()).
+							build();
+					api = apiAdapter.getAPI(apiFilter, false);
+					if(api == null) {
+						throw new AppException("Invalid quota configuration. No API found using API-Name: '" + node.get("api").asText() + " (Version: "+node.get("apiVersion").asText()+").", ErrorCode.INVALID_QUOTA_CONFIG);
+					}
+					
+				}
+				restriction.setRestrictedAPI(api);
+				restriction.setApiId(api.getId());
+			}
+		// No API given, which means apply the Quota to all APIs
+		} else {
+			restriction.setApiId("*");
+		}
+		validateRestriction(restriction);
 		return restriction;
+	}
+	
+	private void validateRestriction(QuotaRestriction restriction) throws AppException {
+		if(restriction.getType()==QuotaRestrictiontype.throttlemb) {
+			if(restriction.getConfig().get("period")==null || restriction.getConfig().get("per")==null || restriction.getConfig().get("mb")==null) {
+				throw new AppException("Invalid quota config. For type 'throttlemb' the following configs are required: period, per, mb", ErrorCode.INVALID_QUOTA_CONFIG);
+			}
+		} else if(restriction.getType()==QuotaRestrictiontype.throttle) {
+			if(restriction.getConfig().get("period")==null || restriction.getConfig().get("per")==null || restriction.getConfig().get("messages")==null) {
+				throw new AppException("Invalid quota config. For type 'throttle' the following configs are required: period, per, messages", ErrorCode.INVALID_QUOTA_CONFIG);
+			}
+		} else {
+			throw new AppException("Unsupported Quota-Type: '" + restriction.getType() + "'. Must be either: throttle or throttlemb", ErrorCode.INVALID_QUOTA_CONFIG);
+		}
+		
+		
+		Pattern pattern = Pattern.compile("^("+validPeriods+")$");
+		Matcher matcher = pattern.matcher(restriction.getConfig().get("period"));
+		if(!matcher.matches()) {
+			throw new AppException("Invalid quota period: '"+restriction.getConfig().get("period")+"'. Must be one of the following: "+validPeriods, ErrorCode.INVALID_QUOTA_CONFIG);
+		}
 	}
 }

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestrictionDeserializer.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/model/QuotaRestrictionDeserializer.java
@@ -52,7 +52,7 @@ public class QuotaRestrictionDeserializer extends JsonDeserializer<QuotaRestrict
 		configMap.put("period", period);
 		configMap.put("per", per);
 		if(node.has("api")) {
-			restriction.setApi(node.get("api").asText());
+			restriction.setApiId(node.get("api").asText());
 		}
 		if(type.equals("throttle")) {
 			configMap.put("messages", quotaConfig.get("messages").asText());

--- a/modules/apim-adapter/src/main/java/com/axway/apim/lib/errorHandling/AppException.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/lib/errorHandling/AppException.java
@@ -11,11 +11,19 @@ public class AppException extends JsonProcessingException {
 	
 	private final ErrorCode error;
 	
+	private String secondMessage;
+	
 	public enum LogLevel {
 		INFO,
 		WARN, 
 		ERROR, 
 		DEBUG
+	}
+	
+	public AppException(String message, String secondMessage, ErrorCode errorCode, Throwable throwable) {
+		super(message, throwable);
+		this.error = errorCode;
+		this.secondMessage = secondMessage;
 	}
 
 	public AppException(String message, ErrorCode errorCode, Throwable throwable) {
@@ -43,6 +51,8 @@ public class AppException extends JsonProcessingException {
 		Throwable cause = null;
 		if(error.getPrintStackTrace() || LOG.isDebugEnabled()) {
 			cause = this;
+		} else {
+			LOG.info("You may enable debug to get more details. See: https://github.com/Axway-API-Management-Plus/apim-cli/wiki/9.1.-Enable-Debug");
 		}
 		switch (error.getLogLevel()) {
 		case INFO: 
@@ -59,10 +69,23 @@ public class AppException extends JsonProcessingException {
 		}
 	}
 
+	public String getSecondMessage() {
+		return secondMessage;
+	}
+
+	public void setSecondMessage(String secondMessage) {
+		this.secondMessage = secondMessage;
+	}
+
 	public String getAllMessages() {
 		String message = getMessage();
+		String secondMessage = getSecondMessage();
+		
 		if(this.getCause()!=null && this.getCause() instanceof AppException) {
 			message += "\n                                 | " + ((AppException)this.getCause()).getAllMessages();
+		}
+		if(secondMessage!=null) {
+			message += "\n                                 | " + secondMessage;
 		}
 		return message;
 	}

--- a/modules/apim-adapter/src/main/java/com/axway/apim/lib/errorHandling/ErrorCode.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/lib/errorHandling/ErrorCode.java
@@ -60,7 +60,7 @@ public enum ErrorCode {
 	ERR_DELETING_ORG					(92, "Organization could not be deleted.", false),
 	ERR_GRANTING_ACCESS_TO_API			(93, "Error granting access to an API.", false),
 	ERR_EXPORTING_API_DAT_FILE			(94, "Error exporting API-Date file.", false),
-	ERR_CREATING_APPLICATION			(95, "Error creating/updating an application.", true),
+	ERR_CREATING_APPLICATION			(95, "Error creating/updating an application.", false),
 	UNXPECTED_ERROR						(99, "An unexpected error occured.", true),
 	CHECK_CERTS_UNXPECTED_ERROR			(100, "There was an unexpected error checking the expiration date of certificates.", false),
 	CHECK_CERTS_FOUND_CERTS				(101, "Certificates found that will expire within the given number of days.", false);

--- a/modules/apim-adapter/src/main/java/com/axway/apim/lib/errorHandling/ErrorCode.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/lib/errorHandling/ErrorCode.java
@@ -61,7 +61,7 @@ public enum ErrorCode {
 	ERR_GRANTING_ACCESS_TO_API			(93, "Error granting access to an API.", false),
 	ERR_EXPORTING_API_DAT_FILE			(94, "Error exporting API-Date file.", false),
 	ERR_CREATING_APPLICATION			(95, "Error creating/updating an application.", true),
-	UNXPECTED_ERROR						(99, "An unexpected error occured."),
+	UNXPECTED_ERROR						(99, "An unexpected error occured.", true),
 	CHECK_CERTS_UNXPECTED_ERROR			(100, "There was an unexpected error checking the expiration date of certificates.", false),
 	CHECK_CERTS_FOUND_CERTS				(101, "Certificates found that will expire within the given number of days.", false);
 

--- a/modules/apim-adapter/src/test/java/com/axway/apim/adapter/apis/APIManagerMockBase.java
+++ b/modules/apim-adapter/src/test/java/com/axway/apim/adapter/apis/APIManagerMockBase.java
@@ -60,6 +60,7 @@ public abstract class APIManagerMockBase {
 		
 
 		apiAdapter.setAPIManagerResponse(new APIFilter.Builder().hasId("72745ed9-f75b-428c-959c-b483eea497a1").build(), testAPI1);
+		apiAdapter.setAPIManagerResponse(new APIFilter.Builder().hasName("apiName-routeKeyD").build(), testAPI1); // Register the name API also based on the API-Name
 		apiAdapter.setAPIManagerResponse(new APIFilter.Builder().hasId("72745ed9-f75b-428c-959c-99999999").build(), testAPI2);
 		apiAdapter.setAPIManagerResponse("72745ed9-f75b-428c-959c-b483eea497a1", new Image());
 		apiAdapter.setAPIManagerResponse("72745ed9-f75b-428c-959c-99999999", new Image());

--- a/modules/apim-adapter/src/test/java/com/axway/apim/adapter/apis/APIManagerMockBase.java
+++ b/modules/apim-adapter/src/test/java/com/axway/apim/adapter/apis/APIManagerMockBase.java
@@ -60,7 +60,8 @@ public abstract class APIManagerMockBase {
 		
 
 		apiAdapter.setAPIManagerResponse(new APIFilter.Builder().hasId("72745ed9-f75b-428c-959c-b483eea497a1").build(), testAPI1);
-		apiAdapter.setAPIManagerResponse(new APIFilter.Builder().hasName("apiName-routeKeyD").build(), testAPI1); // Register the name API also based on the API-Name
+		apiAdapter.setAPIManagerResponse(new APIFilter.Builder().hasName("apiName-routeKeyD").build(), testAPI1); // Register the same API also based on the API-Name
+		apiAdapter.setAPIManagerResponse(new APIFilter.Builder().hasApiPath("/query-string-api-oadmin-839").build(), testAPI1); // Register the same API also based on the API-Path
 		apiAdapter.setAPIManagerResponse(new APIFilter.Builder().hasId("72745ed9-f75b-428c-959c-99999999").build(), testAPI2);
 		apiAdapter.setAPIManagerResponse("72745ed9-f75b-428c-959c-b483eea497a1", new Image());
 		apiAdapter.setAPIManagerResponse("72745ed9-f75b-428c-959c-99999999", new Image());

--- a/modules/apis/src/main/java/com/axway/apim/api/export/jackson/serializer/APIQuotaSerializer.java
+++ b/modules/apis/src/main/java/com/axway/apim/api/export/jackson/serializer/APIQuotaSerializer.java
@@ -34,7 +34,7 @@ public class APIQuotaSerializer extends StdSerializer<APIQuota> {
 		apiQuota.setSystem(null);
 		apiQuota.setType(null);
 		for(QuotaRestriction restriction : apiQuota.getRestrictions()) {
-			restriction.setApi(null );
+			restriction.setApiId(null );
 		}
 		defaultSerializer.serialize(apiQuota, jgen, provider);
 	}

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/APIImportConfigAdapter.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/APIImportConfigAdapter.java
@@ -168,9 +168,9 @@ public class APIImportConfigAdapter {
 				apiConfig = baseConfig;
 			}
 		} catch (JsonParseException e) {
-			throw new AppException("Cannot parse API-Config file(s)", ErrorCode.CANT_READ_JSON_PAYLOAD, e);
+			throw new AppException("Cannot parse API-Config file(s). Exception: " + e.getClass().getName() + ": " + e.getMessage(), ErrorCode.CANT_READ_JSON_PAYLOAD, e);
 		} catch (Exception e) {
-			throw new AppException("Error reading API-Config file(s)", ErrorCode.CANT_READ_CONFIG_FILE, e);
+			throw new AppException("Error reading API-Config file(s). Exception: " + e.getClass().getName() + ": " + e.getMessage(), ErrorCode.CANT_READ_CONFIG_FILE, e);
 		}
 	}
 

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/APIImportConfigAdapter.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/APIImportConfigAdapter.java
@@ -67,6 +67,7 @@ import com.axway.apim.api.model.Organization;
 import com.axway.apim.api.model.OutboundProfile;
 import com.axway.apim.api.model.QuotaRestriction;
 import com.axway.apim.api.model.QuotaRestrictionDeserializer;
+import com.axway.apim.api.model.QuotaRestrictionDeserializer.DeserializeMode;
 import com.axway.apim.api.model.SecurityDevice;
 import com.axway.apim.api.model.SecurityProfile;
 import com.axway.apim.api.model.apps.ClientApplication;
@@ -136,7 +137,7 @@ public class APIImportConfigAdapter {
 	public APIImportConfigAdapter(String apiConfigFileName, String stage, String pathToAPIDefinition, boolean usingOrgAdmin, String stageConfig) throws AppException {
 		super();
 		SimpleModule module = new SimpleModule();
-		module.addDeserializer(QuotaRestriction.class, new QuotaRestrictionDeserializer());
+		module.addDeserializer(QuotaRestriction.class, new QuotaRestrictionDeserializer(DeserializeMode.configFile));
 		// We would like to get back the original AppExcepption instead of a JsonMappingException
 		mapper.disable(DeserializationFeature.WRAP_EXCEPTIONS);
 		mapper.registerModule(module);

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/APIImportConfigAdapter.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/APIImportConfigAdapter.java
@@ -168,9 +168,9 @@ public class APIImportConfigAdapter {
 				apiConfig = baseConfig;
 			}
 		} catch (JsonParseException e) {
-			throw new AppException("Cannot parse API-Config file(s). Exception: " + e.getClass().getName() + ": " + e.getMessage(), ErrorCode.CANT_READ_JSON_PAYLOAD, e);
+			throw new AppException("Cannot parse API-Config file(s).", "Exception: " + e.getClass().getName() + ": " + e.getMessage(), ErrorCode.CANT_READ_JSON_PAYLOAD, e);
 		} catch (Exception e) {
-			throw new AppException("Error reading API-Config file(s). Exception: " + e.getClass().getName() + ": " + e.getMessage(), ErrorCode.CANT_READ_CONFIG_FILE, e);
+			throw new AppException("Error reading API-Config file(s)", "Exception: " + e.getClass().getName() + ": " + e.getMessage(), ErrorCode.CANT_READ_CONFIG_FILE, e);
 		}
 	}
 

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/APIImportConfigAdapter.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/APIImportConfigAdapter.java
@@ -51,6 +51,8 @@ import org.slf4j.LoggerFactory;
 
 import com.axway.apim.adapter.APIManagerAdapter;
 import com.axway.apim.adapter.clientApps.ClientAppFilter;
+import com.axway.apim.adapter.jackson.QuotaRestrictionDeserializer;
+import com.axway.apim.adapter.jackson.QuotaRestrictionDeserializer.DeserializeMode;
 import com.axway.apim.api.API;
 import com.axway.apim.api.definition.APISpecification;
 import com.axway.apim.api.definition.APISpecificationFactory;
@@ -66,8 +68,6 @@ import com.axway.apim.api.model.OAuthClientProfile;
 import com.axway.apim.api.model.Organization;
 import com.axway.apim.api.model.OutboundProfile;
 import com.axway.apim.api.model.QuotaRestriction;
-import com.axway.apim.api.model.QuotaRestrictionDeserializer;
-import com.axway.apim.api.model.QuotaRestrictionDeserializer.DeserializeMode;
 import com.axway.apim.api.model.SecurityDevice;
 import com.axway.apim.api.model.SecurityProfile;
 import com.axway.apim.api.model.apps.ClientApplication;

--- a/modules/apis/src/main/java/com/axway/apim/apiimport/actions/APIQuotaManager.java
+++ b/modules/apis/src/main/java/com/axway/apim/apiimport/actions/APIQuotaManager.java
@@ -65,7 +65,7 @@ public class APIQuotaManager {
 			List<QuotaRestriction> mergedRestrictions = addOrMergeRestriction(actualRestrictions, desiredRestrictions);
 			// Update the API-ID for the API-Restrictions as the API might be re-created.
 			for(QuotaRestriction restriction : mergedRestrictions) {
-				restriction.setApi(createdAPI.getId());
+				restriction.setApiId(createdAPI.getId());
 				if(restriction.getMethod().equals("*")) continue;
 				// Additionally, we have to change the methodId
 				// Load the method for actualAPI to get the name of the method to which the existing quota is applied to
@@ -80,7 +80,7 @@ public class APIQuotaManager {
 				Iterator<QuotaRestriction> it = currentDefaultQuota.getRestrictions().iterator();
 				while(it.hasNext()) {
 					QuotaRestriction restriction = it.next();
-					if(restriction.getApi().equals(actualState.getId())) {
+					if(restriction.getApiId().equals(actualState.getId())) {
 						it.remove();
 					}
 				}
@@ -106,7 +106,7 @@ public class APIQuotaManager {
 			Iterator<QuotaRestriction> it = desiredRestrictions.iterator();
 			while(it.hasNext()) {
 				QuotaRestriction desiredRestriction = it.next();
-				desiredRestriction.setApi(null);
+				desiredRestriction.setApiId(null);
 				// And compare each desired restriction, if it is already included in the existing restrictions
 				for(QuotaRestriction existingRestriction : mergedRestrictions) {
 					if(desiredRestriction.isSameRestriction(existingRestriction, true)) {

--- a/modules/apps/src/main/java/com/axway/apim/appexport/impl/ApplicationExporter.java
+++ b/modules/apps/src/main/java/com/axway/apim/appexport/impl/ApplicationExporter.java
@@ -20,15 +20,16 @@ public abstract class ApplicationExporter {
 	
 	protected static Logger LOG = LoggerFactory.getLogger(ApplicationExporter.class);
 	
-	public enum ExportImpl {
+	public enum ResultHandler {
 		JSON_EXPORTER(JsonApplicationExporter.class),
 		CONSOLE_EXPORTER(ConsoleAppExporter.class),
-		CSV_EXPORTER(CSVAppExporter.class);
+		CSV_EXPORTER(CSVAppExporter.class),
+		DELETE_APP_HANDLER(DeleteAppHandler.class);
 		
 		private final Class<ApplicationExporter> implClass;
 		
 		@SuppressWarnings({ "rawtypes", "unchecked" })
-		private ExportImpl(Class clazz) {
+		private ResultHandler(Class clazz) {
 			this.implClass = clazz;
 		}
 
@@ -42,7 +43,7 @@ public abstract class ApplicationExporter {
 	
 	boolean hasError = false;
 	
-	public static ApplicationExporter create(ExportImpl exportImpl, AppExportParams params, ExportResult result) throws AppException {
+	public static ApplicationExporter create(ResultHandler exportImpl, AppExportParams params, ExportResult result) throws AppException {
 		try {
 			Object[] intArgs = new Object[] { params, result };
 			Constructor<ApplicationExporter> constructor =
@@ -76,8 +77,8 @@ public abstract class ApplicationExporter {
 				.hasRedirectUrl(params.getRedirectUrl())
 				.hasOrganizationName(params.getOrgName())
 				.includeCustomProperties(getCustomProperties())
-				.includeAppPermissions(true)
-				.includeOauthResources(true)
+				.includeAppPermissions(false)
+				.includeOauthResources(false)
 				.hasApiName(params.getApiName())
 				.includeImage(false);
 		if(params.getCredential()!=null || params.getRedirectUrl()!=null) builder.includeCredentials(true);

--- a/modules/apps/src/main/java/com/axway/apim/appexport/impl/CSVAppExporter.java
+++ b/modules/apps/src/main/java/com/axway/apim/appexport/impl/CSVAppExporter.java
@@ -215,14 +215,14 @@ public class CSVAppExporter extends ApplicationExporter {
 	
 	private String getRestrictedAPI(QuotaRestriction quotaRestriction) throws AppException {
 		if(quotaRestriction==null) return "N/A";
-		API api = apiManager.apiAdapter.getAPIWithId(quotaRestriction.getApi());
+		API api = apiManager.apiAdapter.getAPIWithId(quotaRestriction.getApiId());
 		if(api==null) return "Err";
 		return api.getName();
 	}
 	
 	private String getRestrictedMethod(QuotaRestriction quotaRestriction) throws AppException {
 		if(quotaRestriction==null) return "N/A";
-		API restrictedAPI = apiManager.apiAdapter.getAPIWithId(quotaRestriction.getApi());
+		API restrictedAPI = apiManager.apiAdapter.getAPIWithId(quotaRestriction.getApiId());
 		if(restrictedAPI==null) return "Err";
 		return quotaRestriction.getMethod().equals("*") ? "All Methods" : apiManager.methodAdapter.getMethodForId(restrictedAPI.getId(), quotaRestriction.getMethod()).getName();
 	}

--- a/modules/apps/src/main/java/com/axway/apim/appexport/impl/DeleteAppHandler.java
+++ b/modules/apps/src/main/java/com/axway/apim/appexport/impl/DeleteAppHandler.java
@@ -1,0 +1,52 @@
+package com.axway.apim.appexport.impl;
+
+import java.util.List;
+
+import com.axway.apim.adapter.APIManagerAdapter;
+import com.axway.apim.adapter.clientApps.ClientAppFilter;
+import com.axway.apim.adapter.clientApps.ClientAppFilter.Builder;
+import com.axway.apim.api.model.apps.ClientApplication;
+import com.axway.apim.appexport.lib.AppExportParams;
+import com.axway.apim.lib.CoreParameters;
+import com.axway.apim.lib.ExportResult;
+import com.axway.apim.lib.errorHandling.AppException;
+import com.axway.apim.lib.errorHandling.ErrorCode;
+import com.axway.apim.lib.utils.Utils;
+
+public class DeleteAppHandler extends ApplicationExporter {
+
+	public DeleteAppHandler(AppExportParams params, ExportResult result) {
+		super(params, result);
+	}
+
+	@Override
+	public void export(List<ClientApplication> apps) throws AppException {
+		System.out.println(apps.size() + " applications selected for deletion.");
+		if(CoreParameters.getInstance().isForce()) {
+			System.out.println("Force flag given to delete: "+apps.size()+" Application(s)");
+		} else {
+			if(Utils.askYesNo("Do you wish to proceed? (Y/N)")) {
+			} else {
+				System.out.println("Canceled.");
+				return;
+			}
+		}
+		System.out.println("Okay, going to delete: " + apps.size() + " Application(s)");
+		for(ClientApplication app : apps) {
+			try {
+				APIManagerAdapter.getInstance().appAdapter.deleteApplication(app);
+			} catch(Exception e) {
+				result.setError(ErrorCode.ERR_DELETING_ORG);
+				LOG.error("Error deleting application: " + app.getName());
+			}
+		}
+		System.out.println("Done!");
+		return;
+	}
+
+	@Override
+	public ClientAppFilter getFilter() throws AppException {
+		Builder builder = getBaseFilterBuilder();
+		return builder.build();
+	}
+}

--- a/modules/apps/src/main/java/com/axway/apim/appexport/impl/JsonApplicationExporter.java
+++ b/modules/apps/src/main/java/com/axway/apim/appexport/impl/JsonApplicationExporter.java
@@ -10,7 +10,9 @@ import org.apache.commons.io.FileUtils;
 import com.axway.apim.adapter.APIManagerAdapter;
 import com.axway.apim.adapter.clientApps.ClientAppFilter;
 import com.axway.apim.adapter.jackson.ImageSerializer;
+import com.axway.apim.adapter.jackson.QuotaRestrictionSerializer;
 import com.axway.apim.api.model.Image;
+import com.axway.apim.api.model.QuotaRestriction;
 import com.axway.apim.api.model.apps.ClientApplication;
 import com.axway.apim.appexport.impl.jackson.AppExportSerializerModifier;
 import com.axway.apim.appexport.lib.AppExportParams;
@@ -65,8 +67,11 @@ public class JsonApplicationExporter extends ApplicationExporter {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.registerModule(new SimpleModule().setSerializerModifier(new AppExportSerializerModifier(localFolder)));
 		mapper.registerModule(new SimpleModule().addSerializer(Image.class, new ImageSerializer()));
+		mapper.registerModule(new SimpleModule().addSerializer(QuotaRestriction.class, new QuotaRestrictionSerializer(null)));
+		
 		FilterProvider filter = new SimpleFilterProvider()
 				.setDefaultFilter(SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"id", "apiId", "createdBy", "createdOn", "enabled"}))
+				.addFilter("QuotaRestrictionFilter", SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"api", "apiId"})) // Is handled in ExportApplication
 				.addFilter("APIAccessFilter", SimpleBeanPropertyFilter.filterOutAllExcept(new String[] {"apiName", "apiVersion"}))
 				.addFilter("ApplicationPermissionFilter", SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"userId", "createdBy", "id" }))
 				.addFilter("ClientAppCredentialFilter", SimpleBeanPropertyFilter.serializeAllExcept(new String[] {"applicationId", "id", "createdOn", "createdBy"}))

--- a/modules/apps/src/main/java/com/axway/apim/appexport/impl/JsonApplicationExporter.java
+++ b/modules/apps/src/main/java/com/axway/apim/appexport/impl/JsonApplicationExporter.java
@@ -136,6 +136,7 @@ public class JsonApplicationExporter extends ApplicationExporter {
 				.includeAPIAccess(true)
 				.includeImage(true)
 				.includeOauthResources(true)
+				.includeAppPermissions(true)
 				.build();
 	}
 }

--- a/modules/apps/src/main/java/com/axway/apim/appimport/adapter/JSONConfigClientAppAdapter.java
+++ b/modules/apps/src/main/java/com/axway/apim/appimport/adapter/JSONConfigClientAppAdapter.java
@@ -19,6 +19,8 @@ import com.axway.apim.adapter.apis.APIManagerAPIAdapter;
 import com.axway.apim.adapter.clientApps.ClientAppAdapter;
 import com.axway.apim.adapter.clientApps.ClientAppFilter;
 import com.axway.apim.adapter.jackson.AppCredentialsDeserializer;
+import com.axway.apim.adapter.jackson.QuotaRestrictionDeserializer;
+import com.axway.apim.adapter.jackson.QuotaRestrictionDeserializer.DeserializeMode;
 import com.axway.apim.adapter.user.APIManagerUserAdapter;
 import com.axway.apim.adapter.user.UserFilter;
 import com.axway.apim.api.API;
@@ -26,8 +28,6 @@ import com.axway.apim.api.model.APIAccess;
 import com.axway.apim.api.model.CustomProperties.Type;
 import com.axway.apim.api.model.Image;
 import com.axway.apim.api.model.QuotaRestriction;
-import com.axway.apim.api.model.QuotaRestrictionDeserializer;
-import com.axway.apim.api.model.QuotaRestrictionDeserializer.DeserializeMode;
 import com.axway.apim.api.model.User;
 import com.axway.apim.api.model.apps.ApplicationPermission;
 import com.axway.apim.api.model.apps.ClientAppCredential;
@@ -98,10 +98,10 @@ public class JSONConfigClientAppAdapter extends ClientAppAdapter {
 				this.apps = new ArrayList<ClientApplication>();
 				this.apps.add(app);
 			} catch (Exception pe) {
-				throw new AppException("Cannot read application(s) from config file: " + config, ErrorCode.ERR_CREATING_APPLICATION, pe);
+				throw new AppException("Cannot read application(s) from config file: " + config + ". Exception: " + pe.getClass().getName() + ": " + pe.getMessage(), ErrorCode.ERR_CREATING_APPLICATION, pe);
 			}
 		} catch (Exception e) {
-			throw new AppException("Cannot read application(s) from config file: " + config, ErrorCode.ERR_CREATING_APPLICATION, e);
+			throw new AppException("Cannot read application(s) from config file: " + config + ". Exception: " + e.getClass().getName() + ": " + e.getMessage(), ErrorCode.ERR_CREATING_APPLICATION, e);
 		}
 		try{
 			addImage(apps, configFile.getCanonicalFile().getParentFile());

--- a/modules/apps/src/main/java/com/axway/apim/appimport/adapter/JSONConfigClientAppAdapter.java
+++ b/modules/apps/src/main/java/com/axway/apim/appimport/adapter/JSONConfigClientAppAdapter.java
@@ -25,6 +25,9 @@ import com.axway.apim.api.API;
 import com.axway.apim.api.model.APIAccess;
 import com.axway.apim.api.model.CustomProperties.Type;
 import com.axway.apim.api.model.Image;
+import com.axway.apim.api.model.QuotaRestriction;
+import com.axway.apim.api.model.QuotaRestrictionDeserializer;
+import com.axway.apim.api.model.QuotaRestrictionDeserializer.DeserializeMode;
 import com.axway.apim.api.model.User;
 import com.axway.apim.api.model.apps.ApplicationPermission;
 import com.axway.apim.api.model.apps.ClientAppCredential;
@@ -71,6 +74,7 @@ public class JSONConfigClientAppAdapter extends ClientAppAdapter {
 		// Try to read a list of applications
 		try {
 			mapper.registerModule(new SimpleModule().addDeserializer(ClientAppCredential.class, new AppCredentialsDeserializer()));
+			mapper.registerModule(new SimpleModule().addDeserializer(QuotaRestriction.class, new QuotaRestrictionDeserializer(DeserializeMode.configFile)));
 			baseApps = mapper.readValue(Utils.substitueVariables(configFile), new TypeReference<List<ClientApplication>>(){});
 			if(stageConfig!=null) {
 				throw new AppException("Stage overrides are not supported for application lists.", ErrorCode.CANT_READ_CONFIG_FILE);

--- a/modules/apps/src/main/java/com/axway/apim/appimport/adapter/JSONConfigClientAppAdapter.java
+++ b/modules/apps/src/main/java/com/axway/apim/appimport/adapter/JSONConfigClientAppAdapter.java
@@ -98,10 +98,10 @@ public class JSONConfigClientAppAdapter extends ClientAppAdapter {
 				this.apps = new ArrayList<ClientApplication>();
 				this.apps.add(app);
 			} catch (Exception pe) {
-				throw new AppException("Cannot read application(s) from config file: " + config + ". Exception: " + pe.getClass().getName() + ": " + pe.getMessage(), ErrorCode.ERR_CREATING_APPLICATION, pe);
+				throw new AppException("Cannot read application(s) from config file: " + config, "Exception: " + pe.getClass().getName() + ": " + pe.getMessage(), ErrorCode.ERR_CREATING_APPLICATION, pe);
 			}
 		} catch (Exception e) {
-			throw new AppException("Cannot read application(s) from config file: " + config + ". Exception: " + e.getClass().getName() + ": " + e.getMessage(), ErrorCode.ERR_CREATING_APPLICATION, e);
+			throw new AppException("Cannot read application(s) from config file: " + config, "Exception: " + e.getClass().getName() + ": " + e.getMessage(), ErrorCode.ERR_CREATING_APPLICATION, e);
 		}
 		try{
 			addImage(apps, configFile.getCanonicalFile().getParentFile());

--- a/modules/apps/src/test/java/com/axway/apim/appimport/adapter/JSONClientAppAdapterTest.java
+++ b/modules/apps/src/test/java/com/axway/apim/appimport/adapter/JSONClientAppAdapterTest.java
@@ -135,7 +135,7 @@ public class JSONClientAppAdapterTest extends APIManagerMockBase {
 		assertNotNull(appQuota.getRestrictions(), "appQuota restrictions are null");
 		assertEquals(appQuota.getRestrictions().size(), 1, "Expected one restriction");
 		QuotaRestriction restr = appQuota.getRestrictions().get(0);
-		assertEquals(restr.getApi(), "*");
+		assertEquals(restr.getApiId(), "*");
 		assertEquals(restr.getMethod(), "*");
 		assertEquals(restr.getType(), QuotaRestrictiontype.throttle);
 		assertEquals(restr.getConfig().get("messages"), "9999");

--- a/modules/apps/src/test/java/com/axway/apim/appimport/adapter/JSONClientAppAdapterTest.java
+++ b/modules/apps/src/test/java/com/axway/apim/appimport/adapter/JSONClientAppAdapterTest.java
@@ -181,4 +181,33 @@ public class JSONClientAppAdapterTest extends APIManagerMockBase {
 		assertEquals(restr2.getRestrictedAPI().getName(), "apiName-routeKeyD");
 		assertEquals(restr2.getMethod(), "*");
 	}
+	
+	@Test
+	public void testAppWithQuotaBasedOnAPIPath() throws AppException {
+		String testFile = JSONClientAppAdapterTest.class.getResource(testPackage + "/AppWithQuotaPerAPIPath.json").getPath();
+		assertTrue(new File(testFile).exists(), "Test file doesn't exists");
+		AppImportParams importParams = new AppImportParams();
+		importParams.setConfig(testFile);
+		ClientAppAdapter adapter = new JSONConfigClientAppAdapter(importParams);
+
+		List<ClientApplication> apps = adapter.getApplications();
+		assertEquals(apps.size(), 1, "Expected 1 app returned from the Adapter");
+		ClientApplication app = apps.get(0);
+		assertEquals(app.getName(), "Application with quota");
+		assertEquals(app.getDescription(), "Application that configured quota per API-Path");
+		
+		APIQuota appQuota = app.getAppQuota();
+		assertNotNull(appQuota, "appQuota is null");
+		assertNotNull(appQuota.getRestrictions(), "appQuota restrictions are null");
+		assertEquals(appQuota.getRestrictions().size(), 1, "Expected one restriction");
+		QuotaRestriction restr1 = appQuota.getRestrictions().get(0);
+		assertEquals(restr1.getApiId(), "72745ed9-f75b-428c-959c-b483eea497a1");
+		assertEquals(restr1.getRestrictedAPI().getName(), "apiName-routeKeyD");
+		assertEquals(restr1.getRestrictedAPI().getPath(), "/query-string-api-oadmin-839");
+		assertEquals(restr1.getMethod(), "*");
+		assertEquals(restr1.getType(), QuotaRestrictiontype.throttle);
+		assertEquals(restr1.getConfig().get("messages"), "9999");
+		assertEquals(restr1.getConfig().get("period"), "week");
+		assertEquals(restr1.getConfig().get("per"), "1");
+	}
 }

--- a/modules/apps/src/test/java/com/axway/apim/appimport/adapter/JSONClientAppAdapterTest.java
+++ b/modules/apps/src/test/java/com/axway/apim/appimport/adapter/JSONClientAppAdapterTest.java
@@ -167,8 +167,11 @@ public class JSONClientAppAdapterTest extends APIManagerMockBase {
 		APIQuota appQuota = app.getAppQuota();
 		assertNotNull(appQuota, "appQuota is null");
 		assertNotNull(appQuota.getRestrictions(), "appQuota restrictions are null");
-		assertEquals(appQuota.getRestrictions().size(), 2, "Expected two restrictions");
+		assertEquals(appQuota.getRestrictions().size(), 3, "Expected two restrictions");
 		QuotaRestriction restr1 = appQuota.getRestrictions().get(0);
+		QuotaRestriction restr2 = appQuota.getRestrictions().get(1);
+		QuotaRestriction restr3 = appQuota.getRestrictions().get(2);
+		
 		assertEquals(restr1.getApiId(), "*");
 		assertEquals(restr1.getMethod(), "*");
 		assertEquals(restr1.getType(), QuotaRestrictiontype.throttle);
@@ -176,10 +179,13 @@ public class JSONClientAppAdapterTest extends APIManagerMockBase {
 		assertEquals(restr1.getConfig().get("period"), "week");
 		assertEquals(restr1.getConfig().get("per"), "1");
 		
-		QuotaRestriction restr2 = appQuota.getRestrictions().get(1);
+		
 		assertEquals(restr2.getApiId(), "72745ed9-f75b-428c-959c-b483eea497a1");
 		assertEquals(restr2.getRestrictedAPI().getName(), "apiName-routeKeyD");
 		assertEquals(restr2.getMethod(), "*");
+		
+		assertEquals(restr3.getMethod(), "3b5ebd1c-afdd-4120-bb07-6d74389a4da7");
+		
 	}
 	
 	@Test

--- a/modules/apps/src/test/java/com/axway/apim/appimport/it/appQuota/ImportAppWithQuotasTestIT.java
+++ b/modules/apps/src/test/java/com/axway/apim/appimport/it/appQuota/ImportAppWithQuotasTestIT.java
@@ -9,6 +9,8 @@ import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+import com.axway.apim.adapter.jackson.QuotaRestrictionDeserializer;
+import com.axway.apim.adapter.jackson.QuotaRestrictionDeserializer.DeserializeMode;
 import com.axway.apim.api.model.APIQuota;
 import com.axway.apim.api.model.QuotaRestriction;
 import com.axway.apim.api.model.apps.ClientApplication;
@@ -23,6 +25,7 @@ import com.consol.citrus.context.TestContext;
 import com.consol.citrus.dsl.testng.TestNGCitrusTestRunner;
 import com.consol.citrus.message.MessageType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @Test
 public class ImportAppWithQuotasTestIT extends TestNGCitrusTestRunner implements TestParams {
@@ -78,6 +81,7 @@ public class ImportAppWithQuotasTestIT extends TestNGCitrusTestRunner implements
 		Assert.assertEquals(exportApp.getLastResult().getExportedFiles().size(), 1, "Expected to have one application exported");
 		String exportedConfig = exportApp.getLastResult().getExportedFiles().get(0);
 		
+		mapper.registerModule(new SimpleModule().addDeserializer(QuotaRestriction.class, new QuotaRestrictionDeserializer(DeserializeMode.configFile, true)));
 		ClientApplication exportedApp = mapper.readValue(new File(exportedConfig), ClientApplication.class);
 		
 		Assert.assertNotNull(exportedApp.getAppQuota(), "Exported client application must have application quota");
@@ -102,7 +106,7 @@ public class ImportAppWithQuotasTestIT extends TestNGCitrusTestRunner implements
 		Assert.assertEquals(allAPIsRestri.getApiId(), "*");
 		Assert.assertEquals(allAPIsRestri.getMethod(), "*");
 		
-		Assert.assertEquals(APIRestri.getApiId(), context.getVariable("apiName"));
+		Assert.assertEquals(APIRestri.getRestrictedAPI().getName(), context.getVariable("apiName"));
 		Assert.assertEquals(APIRestri.getRestrictedAPI().getPath(), context.getVariable("apiPath"));
 		Assert.assertEquals(APIRestri.getMethod(), "*");
 	}

--- a/modules/apps/src/test/java/com/axway/apim/appimport/it/appQuota/ImportAppWithQuotasTestIT.java
+++ b/modules/apps/src/test/java/com/axway/apim/appimport/it/appQuota/ImportAppWithQuotasTestIT.java
@@ -87,7 +87,7 @@ public class ImportAppWithQuotasTestIT extends TestNGCitrusTestRunner implements
 		Assert.assertNotNull(exportedApp.getAppQuota(), "Exported client application must have application quota");
 		
 		APIQuota appQuota = exportedApp.getAppQuota();
-		Assert.assertEquals(appQuota.getRestrictions().size(), 2, "Two restrictions are expected.");
+		Assert.assertEquals(appQuota.getRestrictions().size(), 3, "Two restrictions are expected.");
 		QuotaRestriction allAPIsRestri = null;
 		QuotaRestriction APIRestri = null;
 		QuotaRestriction APIMethodRestri = null;
@@ -109,5 +109,7 @@ public class ImportAppWithQuotasTestIT extends TestNGCitrusTestRunner implements
 		Assert.assertEquals(APIRestri.getRestrictedAPI().getName(), context.getVariable("apiName"));
 		Assert.assertEquals(APIRestri.getRestrictedAPI().getPath(), context.getVariable("apiPath"));
 		Assert.assertEquals(APIRestri.getMethod(), "*");
+		
+		Assert.assertNotEquals(APIMethodRestri.getMethod(), "*");
 	}
 }

--- a/modules/apps/src/test/resources/com/axway/apim/appimport/adapter/AppWithQuotaPerAPIName.json
+++ b/modules/apps/src/test/resources/com/axway/apim/appimport/adapter/AppWithQuotaPerAPIName.json
@@ -1,0 +1,29 @@
+{
+  "name": "Application with quota",
+  "description": "Application that configured quota per API-Name",
+  "state": "approved",
+  "appQuota": {
+    "restrictions": [
+      {
+        "api": "*",
+        "method": "*",
+        "type": "throttle",
+        "config": {
+          "messages": "9999",
+          "period": "week",
+          "per": "1"
+        }
+      },
+      {
+        "api": "apiName-routeKeyD",
+        "method": "*",
+        "type": "throttle",
+        "config": {
+          "messages": "9999",
+          "period": "week",
+          "per": "1"
+        }
+      }
+    ]
+  }
+}

--- a/modules/apps/src/test/resources/com/axway/apim/appimport/adapter/AppWithQuotaPerAPIName.json
+++ b/modules/apps/src/test/resources/com/axway/apim/appimport/adapter/AppWithQuotaPerAPIName.json
@@ -23,6 +23,16 @@
           "period": "week",
           "per": "1"
         }
+      },
+      {
+        "api": "apiName-routeKeyD",
+        "method": "addPet",
+        "type": "throttle",
+        "config": {
+          "messages": "9999",
+          "period": "week",
+          "per": "1"
+        }
       }
     ]
   }

--- a/modules/apps/src/test/resources/com/axway/apim/appimport/adapter/AppWithQuotaPerAPIPath.json
+++ b/modules/apps/src/test/resources/com/axway/apim/appimport/adapter/AppWithQuotaPerAPIPath.json
@@ -1,0 +1,20 @@
+{
+  "name": "Application with quota",
+  "description": "Application that configured quota per API-Path",
+  "state": "approved",
+  "appQuota": {
+    "restrictions": [
+      {
+        "api": "Not used",
+        "apiPath": "/query-string-api-oadmin-839",
+        "method": "*",
+        "type": "throttle",
+        "config": {
+          "messages": "9999",
+          "period": "week",
+          "per": "1"
+        }
+      }
+    ]
+  }
+}

--- a/modules/apps/src/test/resources/com/axway/apim/appimport/apps/appQuota/AppWithQuotas.json
+++ b/modules/apps/src/test/resources/com/axway/apim/appimport/apps/appQuota/AppWithQuotas.json
@@ -12,21 +12,21 @@
         "method": "*",
         "type": "throttle",
         "config": {
-          "messages": "${quotaMessages}",
-          "period": "${quotaPeriod}",
+          "messages": "1000",
+          "period": "day",
           "per": "1"
         }
       }, 
       {
-        "api": "*",
+        "api": "${apiName}",
         "method": "*",
         "type": "throttle",
         "config": {
-          "messages": "${quotaMessages}",
-          "period": "${quotaPeriod}",
+          "messages": "2000",
+          "period": "month",
           "per": "1"
         }
-      }, 
+      }
     ]
   }
 }

--- a/modules/apps/src/test/resources/com/axway/apim/appimport/apps/appQuota/AppWithQuotas.json
+++ b/modules/apps/src/test/resources/com/axway/apim/appimport/apps/appQuota/AppWithQuotas.json
@@ -26,6 +26,16 @@
           "period": "month",
           "per": "1"
         }
+      },
+      {
+        "api": "${apiName}",
+        "method": "addPet",
+        "type": "throttle",
+        "config": {
+          "messages": "3000",
+          "period": "hour",
+          "per": "1"
+        }
       }
     ]
   }


### PR DESCRIPTION
QuotaRestrictions refactored. Now a Quota-Restriction contains the underlying restricted API, which is for instance required to support a proper export (incl. the API-Name) and Method-Level quotas.

This PR resolves #145