### PR TITLE
Refactored HTTPClient from Utils into it's own class

### DIFF
--- a/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/adapter/apis/APIManagerAPIAdapter.java
@@ -60,6 +60,7 @@ import com.axway.apim.api.model.apps.ClientApplication;
 import com.axway.apim.lib.CoreParameters;
 import com.axway.apim.lib.errorHandling.AppException;
 import com.axway.apim.lib.errorHandling.ErrorCode;
+import com.axway.apim.lib.utils.URLParser;
 import com.axway.apim.lib.utils.Utils;
 import com.axway.apim.lib.utils.rest.DELRequest;
 import com.axway.apim.lib.utils.rest.GETRequest;
@@ -873,9 +874,10 @@ public class APIManagerAPIAdapter {
 		} else {
 			completeWsdlUrl = api.getApiDefinition().getApiSpecificationFile();
 		}
-		wsdlUrl = extractURI(completeWsdlUrl);
-		username=extractUsername(completeWsdlUrl);
-		pass=extractPassword(completeWsdlUrl);
+		URLParser parser = new URLParser(completeWsdlUrl);
+		wsdlUrl = parser.getUri();
+		username = parser.getUsername();
+		pass = parser.getPassword();
 
 		try {
 			URIBuilder uriBuilder = new URIBuilder(cmd.getAPIManagerURL()).setPath(cmd.getApiBasepath()+"/apirepo/importFromUrl/")
@@ -1140,34 +1142,6 @@ public class APIManagerAPIAdapter {
 		}
 		filterFields += "]";
 		return filterFields;
-	}
-	
-	private String extractUsername(String url) {
-		String[] temp = url.split("@");
-		if(temp.length==2) {
-			return temp[0].substring(0, temp[0].indexOf("/"));
-		}
-		return null;
-	}
-	
-	private String extractPassword(String url) {
-		String[] temp = url.split("@");
-		if(temp.length==2) {
-			return temp[0].substring(temp[0].indexOf("/")+1);
-		}
-		return null;
-	}
-	
-	private String extractURI(String url) throws AppException
-	{
-		String[] temp = url.split("@");
-		if(temp.length==1) {
-			return temp[0];
-		} else if(temp.length==2) {
-			return temp[1];
-		} else {
-			throw new AppException("WSDL-URL has an invalid format. ", ErrorCode.CANT_READ_WSDL_FILE);
-		}
 	}
 	
 	public APIManagerAPIAdapter setAPIManagerResponse(APIFilter filter, String apiManagerResponse) {

--- a/modules/apim-adapter/src/main/java/com/axway/apim/lib/utils/HTTPClient.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/lib/utils/HTTPClient.java
@@ -1,0 +1,93 @@
+package com.axway.apim.lib.utils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+
+import com.axway.apim.lib.errorHandling.AppException;
+import com.axway.apim.lib.errorHandling.ErrorCode;
+
+public class HTTPClient {
+	
+	private URI url;
+	private String password;
+	private String username;
+	
+	private CloseableHttpClient httpClient = null;
+	
+	private HttpClientContext clientContext;
+	
+	public HTTPClient(String url, String username, String password) throws AppException {
+		super();
+		try {
+			this.url = new URI(url);
+			this.password = password;
+			this.username = username;
+			getClient();
+		} catch (URISyntaxException e) {
+			throw new AppException("Error creating HTTP-Client.", ErrorCode.UNXPECTED_ERROR, e);
+		}
+	}
+
+	public void getClient() throws AppException {
+		try {
+			SSLContextBuilder builder = SSLContextBuilder.create();
+			builder.loadTrustMaterial(null, new TrustAllStrategy());
+			SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(), new NoopHostnameVerifier());
+			
+			HttpClientBuilder httpClientBuilder = HttpClients.custom()
+					.setSSLSocketFactory(sslsf);
+			
+			if(this.username!=null) {
+				CredentialsProvider credsProvider = new BasicCredentialsProvider();
+				credsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+				AuthCache authCache = new BasicAuthCache();
+				BasicScheme basicAuth = new BasicScheme();
+				authCache.put( new HttpHost(url.getHost(), url.getPort(), url.getScheme()), basicAuth );
+				clientContext = HttpClientContext.create();
+				clientContext.setAuthCache(authCache);
+	
+				httpClientBuilder.setDefaultCredentialsProvider(credsProvider);
+			}
+		
+			this.httpClient = httpClientBuilder.build();
+		} catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
+			throw new AppException("Error creating HTTP-Client.", ErrorCode.UNXPECTED_ERROR, e);
+		}
+	}
+	
+	public CloseableHttpResponse execute(HttpUriRequest request) throws Exception {
+		CloseableHttpResponse response = httpClient.execute(request, clientContext);
+		return response;
+	}
+	
+	public void close() {
+		try {
+			this.httpClient.close();
+		} catch (IOException e) {
+		}
+	}
+
+}

--- a/modules/apim-adapter/src/test/java/com/axway/lib/utils/URLParserTest.java
+++ b/modules/apim-adapter/src/test/java/com/axway/lib/utils/URLParserTest.java
@@ -44,4 +44,12 @@ public class URLParserTest {
 		String urlToAPIDefinition = "dadasdsa@https://petstore.swagger.io/v2/swagger.json";
 		assertThrows(AppException.class, () -> {new URLParser(urlToAPIDefinition);});
 	}
+	
+	@Test
+	public void testPasswordWithAt() throws AppException {
+		String urlToAPIDefinition = "user@axway.com/abc@12345@https://petstore.swagger.io/v2/swagger.json";
+		URLParser parser = new URLParser(urlToAPIDefinition);
+		Assert.assertEquals(parser.getUsername(), "user@axway.com");
+		Assert.assertEquals(parser.getPassword(), "abc@12345");
+	}
 }


### PR DESCRIPTION
With that the HTTP-Client Context is maintained and the required HTTP-Credentials are being send to the server.

Fixes #277