### PR TITLE
pull request handling host field when overrideBasePathSpec = true

### DIFF
--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/specification/OAS3xSpecification.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/specification/OAS3xSpecification.java
@@ -138,7 +138,11 @@ public class OAS3xSpecification extends APISpecification {
         URI serverURL = URI.create(serverUrl);
         String newUrl = backendBasePath;
         if (StringUtils.isEmpty(backendBasePathURL.getPath())){
-            newUrl = new URIBuilder(URI.create(serverUrl)).setHost(backendBasePathURL.getHost()).setPort(backendBasePathURL.getPort()).build().toString();
+            newUrl = new URIBuilder(URI.create(serverUrl))
+                    .setHost(backendBasePathURL.getHost())
+                    .setPort(backendBasePathURL.getPort())
+                    .setScheme(backendBasePathURL.getProtocol())
+                    .build().toString();
         }
         LOG.info("overriding openapi Servers url with value : {}", newUrl);
         ObjectNode newServer = createObjectNode("url", newUrl);

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/specification/Swagger2xSpecification.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/specification/Swagger2xSpecification.java
@@ -93,17 +93,20 @@ public class Swagger2xSpecification extends APISpecification {
                 }
                 URL url = new URL(backendBasePath);
                 String port = url.getPort() == -1 ? ":" + url.getDefaultPort() : ":" + url.getPort();
+                Boolean adjustedHost = false;
                 if (port.equals(":443") || port.equals(":80")) port = "";
                 if (swagger.get("host") == null) {
                     LOG.debug("Adding new host {}{} to Swagger-File based on backendBasePath: {}", url.getHost(), port, backendBasePath);
                     ((ObjectNode) swagger).put("host", url.getHost() + port);
                     LOG.info("Used the backendBasePath: {} to adjust host the API-Specification.", backendBasePath);
+                    adjustedHost = true;
                 }else {
                     if(swagger.get("host").asText().equals(url.getHost()+port)) {
                         LOG.debug("Swagger Host: '{}' already matches backendBasePath: '{}'. Nothing to do.",swagger.get("host").asText(),backendBasePath);
                     } else if (CoreParameters.getInstance().isOverrideSpecBasePath()){
                         LOG.debug("Replacing existing host: '"+swagger.get("host").asText()+"' in Swagger-File to '"+url.getHost()+port+"' based on configured backendBasePath: '"+backendBasePath+"'");
                         ((ObjectNode)swagger).put("host", url.getHost()+port);
+                        adjustedHost = true;
                     }
                 }
                 //what if the backendBasePath is http?
@@ -113,7 +116,7 @@ public class Swagger2xSpecification extends APISpecification {
                     LOG.debug("Adding protocol: {} to Swagger-Definition", url.getProtocol());
                     ((ObjectNode) swagger).set("schemes", newSchemes);
                 } else {
-                    if (CoreParameters.getInstance().isOverrideSpecBasePath()) {
+                    if (CoreParameters.getInstance().isOverrideSpecBasePath() || adjustedHost) {
                         //I may have a situation where a backendbasepath in http must overwrite host but in swagger file it's declared a scheme in https which is not coherent
                         ArrayNode schemes = (ArrayNode) swagger.get("schemes");
                         schemes.removeAll();

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/specification/Swagger2xSpecification.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/specification/Swagger2xSpecification.java
@@ -100,7 +100,7 @@ public class Swagger2xSpecification extends APISpecification {
                     LOG.info("Used the backendBasePath: {} to adjust host the API-Specification.", backendBasePath);
                 }else {
                     if(swagger.get("host").asText().equals(url.getHost()+port)) {
-                        LOG.debug("Swagger Host: '"+swagger.get("host").asText()+"' already matches backendBasePath: '"+backendBasePath+"'. Nothing to do.");
+                        LOG.debug("Swagger Host: '{}' already matches backendBasePath: '{}'. Nothing to do.",swagger.get("host").asText(),backendBasePath);
                     } else if (CoreParameters.getInstance().isOverrideSpecBasePath()){
                         LOG.debug("Replacing existing host: '"+swagger.get("host").asText()+"' in Swagger-File to '"+url.getHost()+port+"' based on configured backendBasePath: '"+backendBasePath+"'");
                         ((ObjectNode)swagger).put("host", url.getHost()+port);

--- a/modules/apim-adapter/src/main/java/com/axway/apim/api/specification/Swagger2xSpecification.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/api/specification/Swagger2xSpecification.java
@@ -112,6 +112,14 @@ public class Swagger2xSpecification extends APISpecification {
                     newSchemes.add(url.getProtocol());
                     LOG.debug("Adding protocol: {} to Swagger-Definition", url.getProtocol());
                     ((ObjectNode) swagger).set("schemes", newSchemes);
+                } else {
+                    if (CoreParameters.getInstance().isOverrideSpecBasePath()) {
+                        //I may have a situation where a backendbasepath in http must overwrite host but in swagger file it's declared a scheme in https which is not coherent
+                        ArrayNode schemes = (ArrayNode) swagger.get("schemes");
+                        schemes.removeAll();
+                        schemes.add(url.getProtocol());
+                        LOG.debug("Setting protocol: {} to Swagger-Definition", url.getProtocol());
+                    }
                 }
                 if (swagger.get("basePath") == null) {
                     LOG.info("Adding default basePath / to swagger");

--- a/modules/apim-adapter/src/main/java/com/axway/apim/lib/CoreCLIOptions.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/lib/CoreCLIOptions.java
@@ -152,9 +152,6 @@ public class CoreCLIOptions extends CLIOptions {
         option.setRequired(false);
         addOption(option);
 
-        option = new Option("replaceHostInSwagger", "Override API Specification ( open api, Swagger 2)  using backendBasepath");
-        option.setRequired(false);
-        addOption(option);
     }
 
     @Override

--- a/modules/apim-adapter/src/main/java/com/axway/apim/lib/CoreCLIOptions.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/lib/CoreCLIOptions.java
@@ -151,7 +151,6 @@ public class CoreCLIOptions extends CLIOptions {
         option = new Option("overrideSpecBasePath", "Override API Specification ( open api, Swagger 2)  using backendBasepath");
         option.setRequired(false);
         addOption(option);
-
     }
 
     @Override

--- a/modules/apim-adapter/src/main/java/com/axway/apim/lib/CoreParameters.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/lib/CoreParameters.java
@@ -71,7 +71,6 @@ public class CoreParameters implements Parameters {
     private boolean disableCompression;
     private boolean overrideSpecBasePath;
 
-
     public CoreParameters() {
         instance = this;
     }

--- a/modules/apim-adapter/src/main/java/com/axway/apim/lib/CoreParameters.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/lib/CoreParameters.java
@@ -71,7 +71,6 @@ public class CoreParameters implements Parameters {
     private boolean disableCompression;
     private boolean overrideSpecBasePath;
 
-    private boolean replaceHostInSwagger = false;
 
     public CoreParameters() {
         instance = this;

--- a/modules/apim-adapter/src/main/java/com/axway/apim/lib/CoreParameters.java
+++ b/modules/apim-adapter/src/main/java/com/axway/apim/lib/CoreParameters.java
@@ -465,5 +465,4 @@ public class CoreParameters implements Parameters {
     public String toString() {
         return "[hostname=" + hostname + ", username=" + username + ", stage=" + stage + "]";
     }
-
 }

--- a/modules/apim-adapter/src/test/java/com/axway/apim/api/specification/APISpecificationOpenAPI3xTest.java
+++ b/modules/apim-adapter/src/test/java/com/axway/apim/api/specification/APISpecificationOpenAPI3xTest.java
@@ -287,4 +287,18 @@ public class APISpecificationOpenAPI3xTest {
         Assert.assertEquals(swagger.get("servers").size(), 1, "Expected to get only one server url");
         Assert.assertEquals("https://myhost.customer.com:8767/test", swagger.get("servers").get(0).get("url").asText());
     }
+
+	@Test
+	public void overrideServerURLWithBackendBasePath2() throws IOException {
+		CoreParameters coreParameters = CoreParameters.getInstance();
+		coreParameters.setOverrideSpecBasePath(true);
+		byte[] content = getSwaggerContent(TEST_PACKAGE + "/openapi.json");
+		APISpecification apiDefinition = APISpecificationFactory.getAPISpecification(content, "teststore.json", "TestAPI");
+		apiDefinition.configureBasePath("https://myhost.customer.com:8767", null);
+		// Check if the Swagger-File has been changed
+		Assert.assertTrue(apiDefinition instanceof OAS3xSpecification);
+		JsonNode swagger = mapper.readTree(apiDefinition.getApiSpecificationContent());
+		Assert.assertEquals(swagger.get("servers").size(), 1, "Expected to get only one server url");
+		Assert.assertEquals("https://myhost.customer.com:8767/api/v3", swagger.get("servers").get(0).get("url").asText());
+	}
 }

--- a/modules/apim-adapter/src/test/java/com/axway/apim/api/specification/APISpecificationSwagger2xTest.java
+++ b/modules/apim-adapter/src/test/java/com/axway/apim/api/specification/APISpecificationSwagger2xTest.java
@@ -278,4 +278,20 @@ public class APISpecificationSwagger2xTest {
         Assert.assertEquals(swagger.get("schemes").size(), 1);
     }
 
+    @Test
+    public void testSwaggerWithoutHost() throws IOException{
+        CoreParameters.getInstance().setOverrideSpecBasePath(false);
+        byte[] content = getSwaggerContent(testPackage + "/petstore-without-host.json");
+        APISpecification apiDefinition = APISpecificationFactory.getAPISpecification(content, "teststore.json", "Test-API");
+        apiDefinition.configureBasePath("http://anotherHost/test", null);
+
+        Assert.assertTrue(apiDefinition instanceof Swagger2xSpecification);
+        JsonNode swagger = mapper.readTree(apiDefinition.getApiSpecificationContent());
+        Assert.assertEquals(swagger.get("host").asText(), "anotherHost");
+        Assert.assertEquals(swagger.get("basePath").asText(), "/v2");
+        Assert.assertEquals(swagger.get("schemes").get(0).asText(), "http");
+        Assert.assertEquals(swagger.get("schemes").size(), 1);
+    }
+
+
 }

--- a/modules/apim-adapter/src/test/java/com/axway/apim/api/specification/APISpecificationSwagger2xTest.java
+++ b/modules/apim-adapter/src/test/java/com/axway/apim/api/specification/APISpecificationSwagger2xTest.java
@@ -238,13 +238,13 @@ public class APISpecificationSwagger2xTest {
         CoreParameters.getInstance().setOverrideSpecBasePath(true);
         byte[] content = getSwaggerContent(testPackage + "/petstore-only-https-scheme.json");
         APISpecification apiDefinition = APISpecificationFactory.getAPISpecification(content, "teststore.json", "Test-API");
-        apiDefinition.configureBasePath("https://petstore.swagger.io/test", null);
+        apiDefinition.configureBasePath("http://petstore.swagger.io/test", null);
 
         Assert.assertTrue(apiDefinition instanceof Swagger2xSpecification);
         JsonNode swagger = mapper.readTree(apiDefinition.getApiSpecificationContent());
         Assert.assertEquals(swagger.get("host").asText(), "petstore.swagger.io");
         Assert.assertEquals(swagger.get("basePath").asText(), "/test");
-        Assert.assertEquals(swagger.get("schemes").get(0).asText(), "https");
+        Assert.assertEquals(swagger.get("schemes").get(0).asText(), "http");
         Assert.assertEquals(swagger.get("schemes").size(), 1);
     }
 


### PR DESCRIPTION
hi @rathnapandi, linked to issue #413 I've made an analysis comparing oas3 and swagger 2 behavior, in order to share the same logic the overrideBasePathSpec parameter, if true, must override also host for swagger 2.X (as it does already with oas3).
In this pull request you can see the changes in code I made.

Please check it out and tell me what do you think!